### PR TITLE
More cigarettes in pointbuy

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -966,6 +966,36 @@ var/global/list/gear_datums_by_name = list()
 	display_name = "Pack Of Lucky Strikes"
 	path = /obj/item/storage/fancy/cigarettes/lucky_strikes
 
+/datum/gear/smoking/pack_emeraldgreen
+	display_name = "Pack Of Emerald Greens"
+	path = /obj/item/storage/fancy/cigarettes/emeraldgreen
+	cost = 3
+
+/datum/gear/smoking/pack_wygold
+	display_name = "Pack Of Weyland Yutani Golds"
+	path = /obj/item/storage/fancy/cigarettes/wypacket
+	cost = 3
+
+/datum/gear/smoking/pack_koorlander
+	display_name = "Pack Of Koorlander Golds"
+	path = /obj/item/storage/fancy/cigarettes/kpack
+	cost = 3
+
+/datum/gear/smoking/pack_arcturian
+	display_name = "Pack Of Arcturian Aces"
+	path = /obj/item/storage/fancy/cigarettes/arcturian_ace
+	cost = 3
+
+/datum/gear/smoking/pack_ladyfingers
+	display_name = "Pack Of Lady Fingers"
+	path = /obj/item/storage/fancy/cigarettes/lady_finger
+	cost = 3
+
+/datum/gear/smoking/pack_exec
+	display_name = "Pack Of Executive Selects"
+	path = /obj/item/storage/fancy/cigarettes/blackpack
+	cost = 4
+
 /datum/gear/smoking/weed_joint
 	display_name = "Joint of space weed"
 	path = /obj/item/clothing/mask/cigarette/weed
@@ -979,6 +1009,11 @@ var/global/list/gear_datums_by_name = list()
 /datum/gear/smoking/zippo
 	display_name = "Lighter, zippo"
 	path = /obj/item/tool/lighter/zippo
+
+/datum/gear/smoking/goldzippo
+	display_name = "Lighter, golden zippo"
+	path = /obj/item/tool/lighter/zippo/gold
+	cost = 4
 
 /datum/gear/smoking/electronic_cigarette
 	display_name = "Electronic cigarette"


### PR DESCRIPTION

# About the pull request

Gives marines more pointbuy packets of cigarettes, because not every smoker likes lucky strikes. increased by 1-2 points than lucky strikes because they would be rarer, also adds gold zippo because some marine would be dumb enough to spend money on a gold plated zippo

# Explain why it's good for the game

More flavor for characters if John Marine is really an emerald smoker, subtle but something


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: added more cigarette options in the loadout, along with a golden zippo
:cl:
