### PR TITLE
Fixes xenos pathing to unreachable target

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/ai/xeno_ai.dm
+++ b/code/modules/mob/living/carbon/xenomorph/ai/xeno_ai.dm
@@ -8,7 +8,6 @@
 
 	var/ai_move_delay = 0
 	var/path_update_period = (0.5 SECONDS)
-	var/no_path_found = FALSE
 	var/ai_range = 16
 	var/max_travel_distance = 24
 
@@ -24,9 +23,6 @@
 
 	/// The actual cooldown declaration for forceful retargeting, reference forced_retarget_time for time in between checks
 	COOLDOWN_DECLARE(forced_retarget_cooldown)
-
-	/// Amount of times no path found has occured
-	var/no_path_found_amount = 0
 
 	/// The time interval between calculating new paths if we cannot find a path
 	var/no_path_found_period = (2.5 SECONDS)
@@ -162,21 +158,11 @@
 /mob/living/carbon/xenomorph/proc/set_path(list/path)
 	current_path = path
 	if(!path)
-		no_path_found = TRUE
+		COOLDOWN_START(src, no_path_found_cooldown, no_path_found_period)
 
 /mob/living/carbon/xenomorph/proc/move_to_next_turf(turf/T, max_range = ai_range)
 	if(!T)
 		return FALSE
-
-	if(no_path_found)
-
-		if(no_path_found_amount > 0)
-			COOLDOWN_START(src, no_path_found_cooldown, no_path_found_period)
-		no_path_found = FALSE
-		no_path_found_amount++
-		return FALSE
-
-	no_path_found_amount = 0
 
 	if((!current_path || (next_path_generation < world.time && current_target_turf != T)) && COOLDOWN_FINISHED(src, no_path_found_cooldown))
 		if(!XENO_CALCULATING_PATH(src) || current_target_turf != T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes https://github.com/cmss13-devs/cmss13-pve/issues/353 , bringing the scenario in the issue from 138ms to 18ms:
![image](https://github.com/user-attachments/assets/aaa05ed7-b55b-4ce1-aa3e-9b4af1db63d6)
(18ms is an average, it can spike depending on which tick the xenos try to pathfind)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Less performance impact from unreachable targets.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Same scenario as in the issue. `COOLDOWN_START` is triggered, the xeno waits the 2.5 seconds then tries pathfinding again. If the blocker is removed xenos will happily path through it after the cooldown.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: less lag from xenos pathfinding unreachable targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
