### PR TITLE
Weighted Slotting

### DIFF
--- a/code/__DEFINES/stats.dm
+++ b/code/__DEFINES/stats.dm
@@ -8,7 +8,11 @@
 #define FACEHUG_TIER_3 100
 #define FACEHUG_TIER_4 1000
 
+/// Consecutive rounds this player has readied up and failed to get a slot.
+#define PLAYER_STAT_UNASSIGNED_ROUND_STREAK "unassigned_round_streak"
+
 // Stat Categories
 #define STAT_CATEGORY_MARINE "marine"
 #define STAT_CATEGORY_XENO "xeno"
 #define STAT_CATEGORY_YAUTJA "yautja"
+#define STAT_CATEGORY_MISC "misc"

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -144,6 +144,43 @@
 	return null
 
 /**
+ * Shuffles a provided list based on the weight of each element.
+ *
+ * Higher weight elements have a higher probability of being picked and tend to appear earlier in the list.
+ * Unweighted elements are never picked and are discarded.
+ *
+ * Arguments:
+ * * list_to_pick - assoc list in the form of: element = weight
+ *
+ * Returns list of shuffled weighted elements
+ */
+/proc/shuffle_weight(list/list_to_pick)
+	list_to_pick = list_to_pick.Copy() //not inplace
+
+	var/total_weight = 0
+	for(var/item in list_to_pick)
+		if(list_to_pick[item])
+			total_weight += list_to_pick[item]
+		else
+			list_to_pick -= item //discard unweighted
+
+	var/list_to_return = list()
+
+	while(length(list_to_pick))
+		var/target_weight = rand(1, total_weight)
+		for(var/item in list_to_pick)
+			var/item_weight = list_to_pick[item]
+			target_weight -= item_weight
+
+			if(target_weight <= 0)
+				list_to_return += item
+				list_to_pick -= item
+				total_weight -= item_weight
+				break
+
+	return list_to_return
+
+/**
  * Removes any null entries from the list
  * Returns TRUE if the list had nulls, FALSE otherwise
 **/

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -210,6 +210,10 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 		if(!M.ready || M.job)
 			continue
 
+		var/datum/preferences/prefs = M.client.prefs
+		if(prefs.alternate_option == RETURN_TO_LOBBY && !prefs.has_job_priorities()) //only try to assign players that actually want assigned
+			continue
+
 		unassigned_players += M
 
 	if(!length(unassigned_players)) //If we don't have any players, the round can't start.

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -232,9 +232,9 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(2 HOURS to 5 HOURS)
 				new_bonus = 1
 
-		var/streak_bonus = max(get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK) - 2, 0) //+1 per missed round after 2
+		//var/streak_bonus = max(get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK) - 2, 0) //+1 per missed round after 2
 
-		player_weights[cycled_unassigned] = base_weight + new_bonus + streak_bonus
+		player_weights[cycled_unassigned] = base_weight + new_bonus //+ streak_bonus
 
 	unassigned_players = shuffle_weight(unassigned_players)
 
@@ -297,7 +297,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 						if(assign_role(cycled_unassigned, random_job))
 							log_debug("ASSIGNMENT: We have randomly assigned [random_job_name] to [cycled_unassigned]")
-							cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
+							//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 							unassigned_players -= cycled_unassigned
 
 							if(random_job.spawn_positions != -1 && random_job.current_positions >= random_job.spawn_positions)
@@ -312,7 +312,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 					var/datum/job/marine_job = GET_MAPPED_ROLE(JOB_SQUAD_MARINE)
 					if(assign_role(cycled_unassigned, marine_job))
 						log_debug("ASSIGNMENT: We have assigned [marine_job.title] to [cycled_unassigned] via alternate option.")
-						cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
+						//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 						unassigned_players -= cycled_unassigned
 
 						if(marine_job.spawn_positions != -1 && marine_job.current_positions >= marine_job.spawn_positions)
@@ -327,7 +327,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 	log_debug("ASSIGNMENT: Assignment complete. Players unassigned: [length(unassigned_players)] Jobs unassigned: [length(roles_to_assign)]")
 	for(var/mob/new_player/cycled_unassigned in unassigned_players)
-		cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 1)
+		//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 1)
 
 	return roles_to_assign
 
@@ -344,7 +344,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 			if(assign_role(cycled_unassigned, actual_job))
 				log_debug("ASSIGNMENT: We have assigned [job_name] to [cycled_unassigned].")
-				cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
+				//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 				unassigned_players -= cycled_unassigned
 
 				if(actual_job.spawn_positions != -1 && actual_job.current_positions >= actual_job.spawn_positions)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -206,18 +206,18 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	//PART II: Setting up our player variables and lists, to see if we have anyone to destribute.
 
 	unassigned_players = list()
-	for(var/mob/new_player/M in GLOB.player_list)
-		if(!M.ready || M.job) //get only players who are ready and unassigned
+	for(var/mob/new_player/player as anything in GLOB.new_player_list)
+		if(!player.ready || player.job) //get only players who are ready and unassigned
 			continue
 
-		var/datum/preferences/prefs = M.client?.prefs
+		var/datum/preferences/prefs = player.client?.prefs
 		if(!prefs) //either no client to play, or no preferences
 			continue
 
 		if(prefs.alternate_option == RETURN_TO_LOBBY && !prefs.has_job_priorities()) //only try to assign players that could possibly be assigned
 			continue
 
-		unassigned_players += M
+		unassigned_players += player
 
 	if(!length(unassigned_players)) //If we don't have any players, the round can't start.
 		unassigned_players = null

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -246,12 +246,26 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	if(!length(roles_to_assign) || !length(unassigned_players))
 		return
 
+	log_debug("ASSIGNMENT: Building weighted_players list.")
+	var/list/weighted_players = list()
+	for(var/mob/new_player/cycled_unassigned in unassigned_players)
+		//1 base weight + 1 for new players + 1/per missed round
+		var/weight = 1 + (cycled_unassigned.client.get_total_human_playtime() < 5 HOURS) + get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK)
+		weighted_players[cycled_unassigned] = weight
+
+	log_debug("ASSIGNMENT: Weighted shuffling unassigned_players list.")
+	unassigned_players.Cut()
+	while(length(weighted_players))
+		var/mob/new_player/weighted_pick = pick_weight(weighted_players)
+		unassigned_players += weighted_pick
+		weighted_players -= weighted_pick
+
 	log_debug("ASSIGNMENT: Starting prime priority assignments.")
-	for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
+	for(var/mob/new_player/cycled_unassigned in unassigned_players)
 		assign_role_to_player_by_priority(cycled_unassigned, roles_to_assign, unassigned_players, PRIME_PRIORITY)
 
 	log_debug("ASSIGNMENT: Starting regular priority assignments.")
-	for(var/mob/new_player/cycled_unassigned in shuffle(unassigned_players))
+	for(var/mob/new_player/cycled_unassigned in unassigned_players)
 		var/player_assigned_job = FALSE
 
 		for(var/priority in HIGH_PRIORITY to LOW_PRIORITY)
@@ -278,6 +292,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 						if(assign_role(cycled_unassigned, random_job))
 							log_debug("ASSIGNMENT: We have randomly assigned [random_job_name] to [cycled_unassigned]")
+							cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 							unassigned_players -= cycled_unassigned
 
 							if(random_job.spawn_positions != -1 && random_job.current_positions >= random_job.spawn_positions)
@@ -292,6 +307,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 					var/datum/job/marine_job = GET_MAPPED_ROLE(JOB_SQUAD_MARINE)
 					if(assign_role(cycled_unassigned, marine_job))
 						log_debug("ASSIGNMENT: We have assigned [marine_job.title] to [cycled_unassigned] via alternate option.")
+						cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 						unassigned_players -= cycled_unassigned
 
 						if(marine_job.spawn_positions != -1 && marine_job.current_positions >= marine_job.spawn_positions)
@@ -305,6 +321,8 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 					cycled_unassigned.ready = 0
 
 	log_debug("ASSIGNMENT: Assignment complete. Players unassigned: [length(unassigned_players)] Jobs unassigned: [length(roles_to_assign)]")
+	for(var/mob/new_player/cycled_unassigned in unassigned_players)
+		cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 1)
 
 	return roles_to_assign
 
@@ -321,6 +339,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 			if(assign_role(cycled_unassigned, actual_job))
 				log_debug("ASSIGNMENT: We have assigned [job_name] to [cycled_unassigned].")
+				cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 				unassigned_players -= cycled_unassigned
 
 				if(actual_job.spawn_positions != -1 && actual_job.current_positions >= actual_job.spawn_positions)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -236,12 +236,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 		player_weights[cycled_unassigned] = base_weight + new_bonus + streak_bonus
 
-	log_debug("ASSIGNMENT: Weighted shuffling unassigned_players list.")
-	unassigned_players.Cut()
-	while(length(player_weights))
-		var/mob/new_player/weighted_pick = pick_weight(player_weights)
-		unassigned_players += weighted_pick
-		player_weights -= weighted_pick
+	unassigned_players = shuffle_weight(unassigned_players)
 
 	// How many positions do we open based on total pop
 	for(var/i in roles_by_name)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -232,9 +232,9 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 			if(2 HOURS to 5 HOURS)
 				new_bonus = 1
 
-		//var/streak_bonus = max(get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK) - 2, 0) //+1 per missed round after 2
+		var/streak_bonus = max(get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK) - 2, 0) //+1 per missed round after 2
 
-		player_weights[cycled_unassigned] = base_weight + new_bonus //+ streak_bonus
+		player_weights[cycled_unassigned] = base_weight + new_bonus + streak_bonus
 
 	unassigned_players = shuffle_weight(unassigned_players)
 
@@ -297,7 +297,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 						if(assign_role(cycled_unassigned, random_job))
 							log_debug("ASSIGNMENT: We have randomly assigned [random_job_name] to [cycled_unassigned]")
-							//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
+							cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 							unassigned_players -= cycled_unassigned
 
 							if(random_job.spawn_positions != -1 && random_job.current_positions >= random_job.spawn_positions)
@@ -312,7 +312,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 					var/datum/job/marine_job = GET_MAPPED_ROLE(JOB_SQUAD_MARINE)
 					if(assign_role(cycled_unassigned, marine_job))
 						log_debug("ASSIGNMENT: We have assigned [marine_job.title] to [cycled_unassigned] via alternate option.")
-						//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
+						cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 						unassigned_players -= cycled_unassigned
 
 						if(marine_job.spawn_positions != -1 && marine_job.current_positions >= marine_job.spawn_positions)
@@ -327,7 +327,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 	log_debug("ASSIGNMENT: Assignment complete. Players unassigned: [length(unassigned_players)] Jobs unassigned: [length(roles_to_assign)]")
 	for(var/mob/new_player/cycled_unassigned in unassigned_players)
-		//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 1)
+		cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 1)
 
 	return roles_to_assign
 
@@ -344,7 +344,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 			if(assign_role(cycled_unassigned, actual_job))
 				log_debug("ASSIGNMENT: We have assigned [job_name] to [cycled_unassigned].")
-				//cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
+				cycled_unassigned.client.player_data?.adjust_stat(PLAYER_STAT_UNASSIGNED_ROUND_STREAK, STAT_CATEGORY_MISC, 0, TRUE)
 				unassigned_players -= cycled_unassigned
 
 				if(actual_job.spawn_positions != -1 && actual_job.current_positions >= actual_job.spawn_positions)

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -249,9 +249,18 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 	log_debug("ASSIGNMENT: Building weighted_players list.")
 	var/list/weighted_players = list()
 	for(var/mob/new_player/cycled_unassigned in unassigned_players)
-		//1 base weight + 1 for new players + 1/per missed round
-		var/weight = 1 + (cycled_unassigned.client.get_total_human_playtime() < 5 HOURS) + get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK)
-		weighted_players[cycled_unassigned] = weight
+		var/base_weight = 1 //baseline weighting
+
+		var/new_bonus = 0
+		switch(cycled_unassigned.client.get_total_human_playtime()) //+1 for new players, +2 for really new players
+			if(0 to 2 HOURS)
+				new_bonus = 2
+			if(2 HOURS to 5 HOURS)
+				new_bonus = 1
+
+		var/streak_bonus = max(get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK) - 2, 0) //+1 per missed round after 2
+
+		weighted_players[cycled_unassigned] = base_weight + new_bonus + streak_bonus
 
 	log_debug("ASSIGNMENT: Weighted shuffling unassigned_players list.")
 	unassigned_players.Cut()

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -236,7 +236,7 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 		player_weights[cycled_unassigned] = base_weight + new_bonus + streak_bonus
 
-	unassigned_players = shuffle_weight(unassigned_players)
+	unassigned_players = shuffle_weight(player_weights)
 
 	// How many positions do we open based on total pop
 	for(var/i in roles_by_name)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -931,6 +931,17 @@ var/const/MAX_SAVE_SLOTS = 10
 
 	return jobs_to_return
 
+/datum/preferences/proc/has_job_priorities()
+	if(!length(job_preference_list))
+		ResetJobs()
+		return FALSE
+
+	for(var/job in job_preference_list)
+		if(job_preference_list[job] != NEVER_PRIORITY)
+			return TRUE
+
+	return FALSE
+
 /datum/preferences/proc/SetJobDepartment(datum/job/J, priority)
 	if(!J || priority < 0 || priority > 4)
 		return FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -931,6 +931,7 @@ var/const/MAX_SAVE_SLOTS = 10
 
 	return jobs_to_return
 
+/// Returns TRUE if any job has a priority other than NEVER, FALSE otherwise.
 /datum/preferences/proc/has_job_priorities()
 	if(!length(job_preference_list))
 		ResetJobs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

The order in which players pass through the roundstart slotting system is now weighted.

All players have a base weight of 1.
New players under 2 hours human playtime get +2 weight, 2-5 hours get +1 weight.
Each round after the first two a player fails to get a slot, cumulative +1 weight. Resets to 0 upon getting a slot.

Players are still picked randomly, with higher weights having a higher chance to be picked.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Right now, *on average*, every player has an equal opportunity to be picked. But it doesn't feel fair when you're on a 10+ round streak of not being picked.

With this change, *on average*, every player will still be picked the same amount of times as before. But those rounds you get to play should be distributed more evenly, so you don't hit a 10+ round dry spell.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: changed slotting - new players and players that got skipped previous rounds have a higher chance to get a slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
