### PR TITLE
Mirror "Suit storages qdel pockets on Destroy()"

### DIFF
--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -10,6 +10,10 @@
 	pockets.max_storage_space = 4
 	flags_atom |= USES_HEARING
 
+/obj/item/clothing/suit/storage/Destroy()
+	QDEL_NULL(pockets)
+	return ..()
+
 /obj/item/clothing/suit/storage/get_pockets()
 	if(pockets)
 		return pockets


### PR DESCRIPTION
# About the pull request

Mirrors https://github.com/cmss13-devs/cmss13/pull/6990
When `Destroy()`ing, suit storages will now qdel and clean their reference to the `pockets` var.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Harddels bad.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
No player facing changes.
