### PR TITLE
AI valid target cache

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/ai/xeno_ai.dm
+++ b/code/modules/mob/living/carbon/xenomorph/ai/xeno_ai.dm
@@ -235,14 +235,10 @@
 	var/atom/movable/closest_target
 	var/smallest_distance = INFINITY
 
-	for(var/mob/living/carbon/potential_target as anything in GLOB.alive_mob_list)
-		if(!istype(potential_target))
-			continue
+	var/list/valid_targets = SSxeno_ai.get_valid_targets(src)
 
+	for(var/atom/movable/potential_target as anything in valid_targets)
 		if(z != potential_target.z)
-			continue
-
-		if(!potential_target.ai_can_target(src))
 			continue
 
 		var/distance = get_dist(src, potential_target)
@@ -256,59 +252,6 @@
 			continue
 
 		closest_target = potential_target
-		smallest_distance = distance
-
-	for(var/obj/vehicle/multitile/potential_vehicle_target as anything in GLOB.all_multi_vehicles)
-		if(z != potential_vehicle_target.z)
-			continue
-
-		var/distance = get_dist(src, potential_vehicle_target)
-
-		if(distance > ai_range)
-			continue
-
-		if(potential_vehicle_target.health <= 0)
-			continue
-
-		var/multitile_faction = potential_vehicle_target.vehicle_faction
-		if(hive.faction_is_ally(multitile_faction))
-			continue
-
-		var/skip_vehicle
-		var/list/interior_living_mobs = potential_vehicle_target.interior.get_passengers()
-		for(var/mob/living/carbon/human/human_mob in interior_living_mobs)
-			if(!human_mob.ai_can_target(src))
-				continue
-
-			skip_vehicle = FALSE
-			break
-
-		if(skip_vehicle)
-			continue
-
-		viable_targets += potential_vehicle_target
-
-		if(smallest_distance <= distance)
-			continue
-
-		closest_target = potential_vehicle_target
-		smallest_distance = distance
-
-	for(var/obj/structure/machinery/defenses/potential_defense_target as anything in GLOB.all_active_defenses)
-		if(z != potential_defense_target.z)
-			continue
-
-		var/distance = get_dist(src, potential_defense_target)
-
-		if(distance > ai_range)
-			continue
-
-		viable_targets += potential_defense_target
-
-		if(smallest_distance <= distance)
-			continue
-
-		closest_target = potential_defense_target
 		smallest_distance = distance
 
 	var/extra_check_distance = round(smallest_distance * EXTRA_CHECK_DISTANCE_MULTIPLIER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Xeno AI keeps a cache of valid targets discovered that tick. Each hive & caste combo has its own cache.
Each individual xeno still does ranging per target but can distribute the cost of testing allyship and `ai_can_target` and such.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Should reduce duplicated work per-AI on finding targets and hopefully reduce AI's performance overhead.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Master:
![image](https://github.com/user-attachments/assets/bef08718-79aa-43a5-b301-0b565bf37df2)
![image](https://github.com/user-attachments/assets/8610afe8-325a-4fb6-bf85-561ee04f4812)

PR:
![image](https://github.com/user-attachments/assets/b702af17-fc42-4f06-a0ed-d796f1cf73fe)
![image](https://github.com/user-attachments/assets/e1f128f6-6e13-451e-b1cd-e71b08ae2ec2)

There's a lot of moving parts to AI performance. The number of possible targets, the number of agents trying to get to those targets, the difficulty of the terrain, the distance they're trying to move...

All of this makes it hard to tell if the performance in two different games is actually comparible.

What I *can* tell is that the difference in `get_target` is extreme. Before, ~70k calls cost ~35 total seconds. After, ~70k cost **~5** seconds. Its cost is dependent on the number of potential targets, which should have been in the same rough ballpark each time: standard USCM platoon in Master, UPP platoon in PR.

`carbon/proc/ai_can_target`: before 2.9 million calls @ ~25 total seconds, after 250k calls @ 3 total seconds
Dependent on number of targets. In same ballpark both times.

`process_ai`: before 90k calls @ 40 total seconds, after 110k calls @ 28 total seconds
Dependent on number of AI. Hard to judge average xenocount, but both platoons were under repeated attack.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: AI caches valid targets for better performance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
