### PR TITLE
Equalizes toolbelts & tool pouches max_w_class

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -88,6 +88,7 @@
 	desc = "The M276 is the standard load-bearing equipment of the USCM. It consists of a modular belt with various clips. This version lacks any combat functionality, and is commonly used by engineers to transport important tools."
 	icon_state = "utilitybelt"
 	item_state = "utility"
+	max_w_class = SIZE_MEDIUM
 	can_hold = list(
 		/obj/item/tool/crowbar,
 		/obj/item/tool/screwdriver,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes it so the toolbelt can carry the high-capacity blowtorch

# Explain why it's good for the game

Frankly made no sense that a dedicated belt for carrying tools couldn't hold the big welder, yet a pouch clipped to pockets _could_. This ammends that by allowing the toolbelt to lug the big thing around.
Tool-webbing remains unchanged, as I figure the pockets on that are much more size-restricted.

# Testing Photographs and Procedure
Tested locally, works as intended.
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/d7f8b8ba-05e9-41cf-a9cf-54f57b2a6ed7)


</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Toolbelts can now carry the high-capacity blowtorch
/:cl:

