### PR TITLE
Adds a 'slot nickname' field for easily ID'ing chara slots

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -117,6 +117,7 @@ var/const/MAX_SAVE_SLOTS = 20
 
 	//character preferences
 	var/real_name //our character's name
+	var/nickname //the nickname for the saveslot
 	var/be_random_name = FALSE //whether we are a random name every round
 	var/human_name_ban = FALSE
 
@@ -327,6 +328,8 @@ var/const/MAX_SAVE_SLOTS = 20
 			dat += "<h1><u><b>Name:</b></u> "
 			dat += "<a href='?_src_=prefs;preference=name;task=input'><b>[real_name]</b></a>"
 			dat += "<a href='?_src_=prefs;preference=name;task=random'>&reg</A></h1>"
+			dat += "<u><b>Slot nickame:</b></u> "
+			dat += "<a href='?_src_=prefs;preference=nickname;task=input'><b>[nickname ? "[nickname]" : "---"]</b></a><br> "
 			dat += "<b>Always Pick Random Name:</b> <a href='?_src_=prefs;preference=rand_name'><b>[be_random_name ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Always Pick Random Appearance:</b> <a href='?_src_=prefs;preference=rand_body'><b>[be_random_body ? "Yes" : "No"]</b></a><br><br>"
 
@@ -1245,6 +1248,15 @@ var/const/MAX_SAVE_SLOTS = 20
 							real_name = new_name
 						else
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
+
+				if("nickname")
+					var/raw_name = input(user, "Choose a nickname or identifier for this character slot. This is not an in-character nickname:", "Character Preference")  as text|null
+					if (raw_name) // Check to ensure that the user entered text (rather than cancel.)
+						var/new_name = reject_bad_name(raw_name)
+						if(new_name)
+							nickname = new_name
+						else
+							to_chat(user, "<font color='red'>Invalid name. Your slot name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("xeno_vision_level_pref")
 					var/static/list/vision_level_choices = list(XENO_VISION_LEVEL_NO_NVG, XENO_VISION_LEVEL_MID_NVG, XENO_VISION_LEVEL_FULL_NVG)
@@ -2224,10 +2236,11 @@ var/const/MAX_SAVE_SLOTS = 20
 		for(var/i=1, i<=MAX_SAVE_SLOTS, i++)
 			S.cd = "/character[i]"
 			S["real_name"] >> name
+			S["nickname"] >> nickname
 			if(!name) name = "Character[i]"
 			if(i==default_slot)
 				name = "<b>[name]</b>"
-			dat += "<a href='?_src_=prefs;preference=changeslot;num=[i];'>[name]</a><br>"
+			dat += "<a href='?_src_=prefs;preference=changeslot;num=[i];'>[name] ([nickname])</a><br>"
 
 	dat += "<hr>"
 	dat += "<a href='byond://?src=\ref[user];preference=close_load_dialog'>Close</a><br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -328,7 +328,7 @@ var/const/MAX_SAVE_SLOTS = 20
 			dat += "<h1><u><b>Name:</b></u> "
 			dat += "<a href='?_src_=prefs;preference=name;task=input'><b>[real_name]</b></a>"
 			dat += "<a href='?_src_=prefs;preference=name;task=random'>&reg</A></h1>"
-			dat += "<u><b>Slot nickame:</b></u> "
+			dat += "<u><b>Slot label:</b></u> "
 			dat += "<a href='?_src_=prefs;preference=slot_label;task=input'><b>[slot_label ? "[slot_label]" : "---"]</b></a><br> "
 			dat += "<b>Always Pick Random Name:</b> <a href='?_src_=prefs;preference=rand_name'><b>[be_random_name ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Always Pick Random Appearance:</b> <a href='?_src_=prefs;preference=rand_body'><b>[be_random_body ? "Yes" : "No"]</b></a><br><br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -117,7 +117,7 @@ var/const/MAX_SAVE_SLOTS = 20
 
 	//character preferences
 	var/real_name //our character's name
-	var/nickname //the nickname for the saveslot
+	var/slot_label //the nickname for the saveslot
 	var/be_random_name = FALSE //whether we are a random name every round
 	var/human_name_ban = FALSE
 
@@ -329,7 +329,7 @@ var/const/MAX_SAVE_SLOTS = 20
 			dat += "<a href='?_src_=prefs;preference=name;task=input'><b>[real_name]</b></a>"
 			dat += "<a href='?_src_=prefs;preference=name;task=random'>&reg</A></h1>"
 			dat += "<u><b>Slot nickame:</b></u> "
-			dat += "<a href='?_src_=prefs;preference=nickname;task=input'><b>[nickname ? "[nickname]" : "---"]</b></a><br> "
+			dat += "<a href='?_src_=prefs;preference=slot_label;task=input'><b>[slot_label ? "[slot_label]" : "---"]</b></a><br> "
 			dat += "<b>Always Pick Random Name:</b> <a href='?_src_=prefs;preference=rand_name'><b>[be_random_name ? "Yes" : "No"]</b></a><br>"
 			dat += "<b>Always Pick Random Appearance:</b> <a href='?_src_=prefs;preference=rand_body'><b>[be_random_body ? "Yes" : "No"]</b></a><br><br>"
 
@@ -1249,12 +1249,12 @@ var/const/MAX_SAVE_SLOTS = 20
 						else
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
-				if("nickname")
-					var/raw_name = input(user, "Choose a nickname or identifier for this character slot. This is not an in-character nickname:", "Character Preference")  as text|null
+				if("slot_label")
+					var/raw_name = input(user, "Choose a short label or identifier for this character slot. This is not an in-character nickname:", "Character Preference")  as text|null
 					if (raw_name) // Check to ensure that the user entered text (rather than cancel.)
 						var/new_name = reject_bad_name(raw_name)
 						if(new_name)
-							nickname = new_name
+							slot_label = new_name
 						else
 							to_chat(user, "<font color='red'>Invalid name. Your slot name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
@@ -2236,11 +2236,11 @@ var/const/MAX_SAVE_SLOTS = 20
 		for(var/i=1, i<=MAX_SAVE_SLOTS, i++)
 			S.cd = "/character[i]"
 			S["real_name"] >> name
-			S["nickname"] >> nickname
+			S["slot_label"] >> slot_label
 			if(!name) name = "Character[i]"
 			if(i==default_slot)
 				name = "<b>[name]</b>"
-			dat += "<a href='?_src_=prefs;preference=changeslot;num=[i];'>[name] ([nickname])</a><br>"
+			dat += "<a href='?_src_=prefs;preference=changeslot;num=[i];'>[name] ([slot_label])</a><br>"
 
 	dat += "<hr>"
 	dat += "<a href='byond://?src=\ref[user];preference=close_load_dialog'>Close</a><br>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -514,6 +514,7 @@
 	//Character
 	S["OOC_Notes"] >> metadata
 	S["real_name"] >> real_name
+	S["nickname"] >> nickname
 	S["name_is_always_random"] >> be_random_name
 	S["body_is_always_random"] >> be_random_body
 	S["gender"] >> gender
@@ -673,6 +674,7 @@
 	//Character
 	S["OOC_Notes"] << metadata
 	S["real_name"] << real_name
+	S["nickname"] << nickname
 	S["name_is_always_random"] << be_random_name
 	S["body_is_always_random"] << be_random_body
 	S["gender"] << gender

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -514,7 +514,7 @@
 	//Character
 	S["OOC_Notes"] >> metadata
 	S["real_name"] >> real_name
-	S["nickname"] >> nickname
+	S["slot_label"] >> slot_label
 	S["name_is_always_random"] >> be_random_name
 	S["body_is_always_random"] >> be_random_body
 	S["gender"] >> gender
@@ -674,7 +674,7 @@
 	//Character
 	S["OOC_Notes"] << metadata
 	S["real_name"] << real_name
-	S["nickname"] << nickname
+	S["slot_label"] << slot_label
 	S["name_is_always_random"] << be_random_name
 	S["body_is_always_random"] << be_random_body
 	S["gender"] << gender


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds a new field on the character setup screen with which to give the save slot a 'nickname' for easier identification at a glance, so you can tell what characters are for USCM, UPP, TWE, etc etc.

# Explain why it's good for the game

No more getting mildly confused about which chara is meant for which faction if you have a gagglefuck of them made up.

# Testing Photographs and Procedure
Tested extensively on a local instance, works without issue and as intended.
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/65faec86-23cc-4c48-80e3-153f962caee6)
The final version of the code removed the (brackets) from either side of the slot nickname result on the setup page, but retains it on the load-slot window.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Adds a new 'nickname' for character slots
ui: adjusted the character setup menu to have a field for the above
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
