### PR TITLE
railgun should probably be able to see flares

### DIFF
--- a/code/modules/cm_tech/implements/railgun.dm
+++ b/code/modules/cm_tech/implements/railgun.dm
@@ -255,7 +255,7 @@ GLOBAL_DATUM(railgun_eye_location, /datum/coords)
 	SIGNAL_HANDLER
 
 	H.see_in_dark = 50
-	H.sight = (SEE_TURFS|BLIND)
+	H.sight = (SEE_TURFS|SEE_OBJS|BLIND)
 	H.see_invisible = SEE_INVISIBLE_MINIMUM
 	return COMPONENT_OVERRIDE_UPDATE_SIGHT
 


### PR DESCRIPTION
Makes it so railgun operators can see objects, so they can see flares and lights and shit. Beforehand I'm not exactly sure how they were meant to get targets to fire on.