### PR TITLE
Removes HEFA Knights Reference From Big Red

### DIFF
--- a/maps/map_files/BigRed/BigRed.dmm
+++ b/maps/map_files/BigRed/BigRed.dmm
@@ -14850,13 +14850,6 @@
 	},
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
-"kBD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/explosive/grenade/high_explosive/frag{
-	desc = "High-Explosive Fragmenting-Antipersonnel. A small, but deceptively strong fragmentation grenade that has been phasing out the M15 fragmentation grenades alongside the M40 HEDP. Capable of being loaded in the M92 Launcher, or thrown by hand. This one seems to have weird insciptions all over it. You can barely make out 'PrAIs3 thE H3f@ G0d'"
-	},
-/turf/open/floor/plating/platingdmg3/west,
-/area/bigredv2/caves/mining)
 "kBE" = (
 /obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/plating,
@@ -15510,11 +15503,6 @@
 "kZa" = (
 /turf/open/floor/asteroidwarning/northeast,
 /area/bigredv2/outside/e)
-"kZG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/bible/hefa,
-/turf/open/floor/plating,
-/area/bigredv2/caves/mining)
 "kZO" = (
 /obj/structure/bookcase{
 	icon_state = "book-5"
@@ -36043,7 +36031,7 @@ iLV
 qux
 xXY
 ffg
-kBD
+ffg
 ffg
 pKg
 cfT
@@ -36477,7 +36465,7 @@ qhk
 cVd
 nZC
 xfP
-kZG
+cVd
 ffg
 bJf
 cfT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Removes the HEFA grenade and the meme bible from the mining site.

# Explain why it's good for the game
It's a dumb, stupid, idiotic, stupid, ridiculous, stupid, immersion breaking, completely unnecessary, stupid joke from PvP and shouldn't be a standard part of the map.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: Random M40 HEFA removed from Big Red
del: Random meme bible removed from Big Red
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
