### PR TITLE
M41 Magazine Can Sprite Fix

### DIFF
--- a/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/magazine_boxes.dm
@@ -557,7 +557,7 @@
 /obj/item/ammo_box/magazine/mk1
 	name = "magazine box (M41A MK1 x 10)"
 	overlay_ammo_type = "_reg_mk1"
-	overlay_gun_type = "_mk1"
+	overlay_gun_type = "_m41"
 	overlay_content = "_reg"
 	magazine_type = /obj/item/ammo_magazine/rifle/m41aMK1
 	allowed_magazines = list(/obj/item/ammo_magazine/rifle/m41aMK1/recon)


### PR DESCRIPTION
PvP update merger brought about with it a very PvP change, putting a big MK1 on the M41 cans, this reverts it back to M41. Small change.