### PR TITLE
Construction Pouches carry filled Sandbags + Bag Stack Change

### DIFF
--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -65,12 +65,12 @@
 	throwforce = 15
 	throw_speed = SPEED_VERY_FAST
 	throw_range = 20
-	max_amount = 25
+	max_amount = 35
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	stack_id = "sandbags"
 
 /obj/item/stack/sandbags/large_stack
-	amount = 35
+	amount = 50
 
 /obj/item/stack/sandbags/small_stack
 	amount = 5

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -60,7 +60,7 @@
 	icon = 'icons/obj/items/marine-items.dmi'
 	icon_state = "sandbag_pile"
 	item_state = "sandbag_pile"
-	w_class = SIZE_LARGE
+	w_class = SIZE_MEDIUM
 	force = 9
 	throwforce = 15
 	throw_speed = SPEED_VERY_FAST
@@ -70,7 +70,7 @@
 	stack_id = "sandbags"
 
 /obj/item/stack/sandbags/large_stack
-	amount = 25
+	amount = 35
 
 /obj/item/stack/sandbags/small_stack
 	amount = 5

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -65,7 +65,7 @@
 	throwforce = 15
 	throw_speed = SPEED_VERY_FAST
 	throw_range = 20
-	max_amount = 35
+	max_amount = 50
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	stack_id = "sandbags"
 

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1186,7 +1186,7 @@
 		/obj/item/stack/cable_coil,
 		/obj/item/stack/tile,
 		/obj/item/tool/shovel/etool,
-		/obj/item/stack/sandbags
+		/obj/item/stack/sandbags,
 		/obj/item/stack/sandbags_empty,
 		/obj/item/stack/sandbags/large_stack
 		/obj/item/device/lightreplacer,

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1188,7 +1188,6 @@
 		/obj/item/tool/shovel/etool,
 		/obj/item/stack/sandbags,
 		/obj/item/stack/sandbags_empty,
-		/obj/item/stack/sandbags/large_stack,
 		/obj/item/device/lightreplacer,
 		/obj/item/weapon/gun/smg/nailgun/compact,
 	)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1186,7 +1186,9 @@
 		/obj/item/stack/cable_coil,
 		/obj/item/stack/tile,
 		/obj/item/tool/shovel/etool,
+		/obj/item/stack/sandbags
 		/obj/item/stack/sandbags_empty,
+		/obj/item/stack/sandbags/large_stack
 		/obj/item/device/lightreplacer,
 		/obj/item/weapon/gun/smg/nailgun/compact,
 	)

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1188,7 +1188,7 @@
 		/obj/item/tool/shovel/etool,
 		/obj/item/stack/sandbags,
 		/obj/item/stack/sandbags_empty,
-		/obj/item/stack/sandbags/large_stack
+		/obj/item/stack/sandbags/large_stack,
 		/obj/item/device/lightreplacer,
 		/obj/item/weapon/gun/smg/nailgun/compact,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Simple change that lets filled sandbags be carried by conpouches, as well as ups their stack sizes to be more comparable to sheets.
Sandbags go up to 35 bags, with the large_stack spawnable having 50 simply for prop convenience

Did some quick and dirty testing and everything looks fine but this is also my first PR literally ever

# Explain why it's good for the game

I made this change in order to encourage people actually using sandbags. As it stands now, nobody ever brings sandbags, and I think from both a gameplay and thematic/lore perspective it makes much more sense for Marines (or any combat force, really) to have sandbags on-hand for quick emergency fortification rather than hundreds of pounds of steel sheets. 

As it stands now, metal sheets are just the default, required object to bring if the platoon things they will ever need fortifications and I find that weird honestly. It also doesn't make sense that sandbags are larger and take up more space than metal sheets, despite being slower since you could only carry empty bags, not being able to be carried in conpouches when filled, and enduring less damage than metal sheets anyways.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/128232b8-bc12-4bb5-92ea-6926420eba2f)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
