### PR TITLE
Fixes the Automag selection in the loadout

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -783,7 +783,7 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 
 /datum/gear/weapon/hg44
 	display_name = "HG 44 'Automag' Pistol"
-	path = /obj/item/storage/box/loadout/HG45_marine_loadout
+	path = /obj/item/storage/box/loadout/HG44_loadout
 	allowed_origins = USCM_ORIGINS
 
 /datum/gear/weapon/spearhead


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Sorts a typo in the code that made the automag pistol spawn as the mil-spec HG-45

# Explain why it's good for the game

Typos bad, selected items spawning in as the wrong thing even badder.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
fix: Un-typos a line of code in the loadout stuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
