### PR TITLE
Brings back PltCo medal awarding

### DIFF
--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -599,8 +599,8 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 		to_chat(user, SPAN_WARNING("You must have an authenticated ID Card to award medals."))
 		return
 
-	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades)))
-		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
+	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.platco_paygrades) || (card.paygrade in GLOB.highcom_paygrades)))
+		to_chat(user, SPAN_WARNING("Only an Officer can award medals!"))
 		return
 
 	if(!card.registered_ref)

--- a/code/datums/medal_awards.dm
+++ b/code/datums/medal_awards.dm
@@ -267,7 +267,7 @@ GLOBAL_LIST_INIT(human_medals, list(MARINE_CONDUCT_MEDAL))
 		return
 
 	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.platco_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades)))
-		to_chat(user, SPAN_WARNING("Only a Senior Officer can award medals!"))
+		to_chat(user, SPAN_WARNING("Only an Officer can award medals!"))
 		return
 
 	if(!card.registered_ref)
@@ -599,7 +599,7 @@ GLOBAL_DATUM_INIT(ic_medals_panel, /datum/ic_medal_panel, new)
 		to_chat(user, SPAN_WARNING("You must have an authenticated ID Card to award medals."))
 		return
 
-	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.platco_paygrades) || (card.paygrade in GLOB.highcom_paygrades)))
+	if(!((card.paygrade in GLOB.co_paygrades) || (card.paygrade in GLOB.platco_paygrades) || (card.paygrade in GLOB.uscm_highcom_paygrades)))
 		to_chat(user, SPAN_WARNING("Only an Officer can award medals!"))
 		return
 

--- a/code/datums/paygrades/paygrade.dm
+++ b/code/datums/paygrades/paygrade.dm
@@ -39,6 +39,28 @@ GLOBAL_LIST_INIT(co_paygrades, list(
 	PAY_SHORT_AO4
 ))
 
+GLOBAL_LIST_INIT(highcom_paygrades, list(
+	"PvI",
+	"AO7",
+	"NO7",
+	"MO7",
+	"AO8",
+	"NO8",
+	"MO8",
+	"AO9",
+	"NO9",
+	"MO9",
+	"AO10",
+	"NO10",
+	"MO10",
+	"AO10C",
+	"NO10C",
+	"MO10C",
+	"PvO8",
+	"PvO9",
+	"PvCM"
+))
+
 /datum/paygrade/New()
 	. = ..()
 	switch(default_faction)

--- a/code/datums/paygrades/paygrade.dm
+++ b/code/datums/paygrades/paygrade.dm
@@ -39,28 +39,6 @@ GLOBAL_LIST_INIT(co_paygrades, list(
 	PAY_SHORT_AO4
 ))
 
-GLOBAL_LIST_INIT(highcom_paygrades, list(
-	"PvI",
-	"AO7",
-	"NO7",
-	"MO7",
-	"AO8",
-	"NO8",
-	"MO8",
-	"AO9",
-	"NO9",
-	"MO9",
-	"AO10",
-	"NO10",
-	"MO10",
-	"AO10C",
-	"NO10C",
-	"MO10C",
-	"PvO8",
-	"PvO9",
-	"PvCM"
-))
-
 /datum/paygrade/New()
 	. = ..()
 	switch(default_faction)
@@ -84,7 +62,7 @@ GLOBAL_LIST_INIT(highcom_paygrades, list(
 				.[pg_id] = new PG
 
 GLOBAL_LIST_INIT(platco_paygrades, list(
-	"MO3",
-	"MO2",
-	"MO1",
+	PAY_SHORT_MO3,
+	PAY_SHORT_MO2,
+	PAY_SHORT_MO1,
 ))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Fixes something the upstream merge messed up amidst the torrent of changes, allowing the lowly LT to once again issue medals for their platoon.

# Explain why it's good for the game

Is this bit even needed? We almost never have command personnel above Captain rank present, so limiting medals being issued out to those at O4 paygrade and above is inane.

# Testing Photographs and Procedure
Compiled fine with no errors

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
qol: Platoon Commanders can once again issue medals to those under their command
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
