### PR TITLE
Lets try this again: Makes cassette pouches hold slightly more tapes

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -1397,7 +1397,7 @@
 	var/base_icon_state = "cassette_pouch"
 	w_class = SIZE_SMALL
 	can_hold = list(/obj/item/device/cassette_tape, /obj/item/tape/regulation)
-	storage_slots = 3
+	storage_slots = 5
 
 /obj/item/storage/pouch/cassette/update_icon()
 	underlays.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Does what the title says

Tested, works fine since it's literally just a number change

# Explain why it's good for the game

Lets people take slightly more music for vibes purposes

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
qol: Made cassette pouches slightly more worth it
balance: From 3 slots to 5

/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
