### PR TITLE
10x28mm Ammo Box Addition

### DIFF
--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -15805,9 +15805,6 @@
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/engineering)
 "eZR" = (
-/obj/item/storage/box/guncase/flamer/fuel{
-	pixel_y = 8
-	},
 /obj/structure/machinery/light/small/blue{
 	dir = 8;
 	light_color = "#dae2ff";
@@ -15815,6 +15812,10 @@
 	pixel_y = 10
 	},
 /obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/ammo_box/rounds/smartgun{
+	pixel_y = 8
+	},
+/obj/item/ammo_box/rounds/smartgun,
 /turf/open/floor/almayer/mono,
 /area/golden_arrow/platoonarmory)
 "fbw" = (
@@ -15971,6 +15972,9 @@
 	light_color = "#dae2ff"
 	},
 /obj/structure/surface/table/almayer,
+/obj/item/storage/box/guncase/flamer/fuel{
+	pixel_y = 8
+	},
 /obj/item/tool/crowbar,
 /turf/open/floor/almayer,
 /area/golden_arrow/platoonarmory)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Adds two 10x28mm ammo boxes to the Golden Arrow armory.

# Explain why it's good for the game
The Smartgunner right now has ample pre-loaded ammunition already, with one loaded in the gun and two loaded in the belt. However this has left those who want to buddy with the Smartgunner as a gun team without anything to carry. Without directly just increasing the drum mags of the gunner, the loose ammo boxes now provide an additional thing for carriers to keep on themselves for the gunner and manage in operation. Since drums take a while to load now, it also means resource management can play a bigger part in the Smartgunner-carrier gameplay style.

# Changelog

:cl:
add: 2 10x28 Ammunition Boxes added to the Golden Arrow Armory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
