### PR TITLE
Sections From The Tech Man Are Now Properly Referenced

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -19,9 +19,9 @@
 
 // Job name defines
 #define JOB_SQUAD_MARINE "Rifleman"
-#define JOB_SQUAD_LEADER "Platoon Sergeant"
+#define JOB_SQUAD_LEADER "Section Sergeant"
 #define JOB_SQUAD_ENGI "Combat Technician"
-#define JOB_SQUAD_MEDIC "Platoon Corpsman"
+#define JOB_SQUAD_MEDIC "Corpsman"
 #define JOB_SQUAD_SPECIALIST "Weapons Specialist"
 #define JOB_SQUAD_TEAM_LEADER "Squad Sergeant"
 #define JOB_SQUAD_SMARTGUN "Smartgunner"

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -10,7 +10,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/leader
 	gear_preset_secondary = /datum/equipment_preset/uscm/leader/lesser_rank
-	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are responsible for the men and women of your entire platoon.</a> Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are responsible for the men and women of your entire section.</a> Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
 
 	job_options = list(GYSGT_VARIANT = "GYSGT", SSGT_VARIANT = "SSGT")
 

--- a/code/game/jobs/job/marine/squad/medic.dm
+++ b/code/game/jobs/job/marine/squad/medic.dm
@@ -10,7 +10,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/medic
 	gear_preset_secondary = /datum/equipment_preset/uscm/medic/lesser_rank
-	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You tend the wounds of your squad mates</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters.<br><b>You remember that you've stored your personal gear and uniform are located in your medical office.</b>"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You tend the wounds of your fellow Marines</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters.<br><b>You remember that you've stored your personal gear and uniform are located in your medical office.</b>"
 
 	job_options = list(CPL_VARIANT = "CPL", LCPL_VARIANT = "LCPL")
 

--- a/code/game/jobs/job/marine/squad/tl.dm
+++ b/code/game/jobs/job/marine/squad/tl.dm
@@ -8,7 +8,7 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/tl
-	entry_message_body = "You are the <a href='"+WIKI_PLACEHOLDER+"'>Squad Leader.</a> Your task is leading the designated squad and utilize available ordnance. If the platoon leader dies, you are expected to lead in their place.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
+	entry_message_body = "You are the <a href='"+WIKI_PLACEHOLDER+"'>Squad Leader.</a> Your task is leading the designated squad and utilize available ordnance. If the section sergeant dies, you are expected to lead in their place.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
 
 	job_options = list(SGT_VARIANT = "SGT")
 

--- a/code/game/jobs/job/marine/squad_info.dm
+++ b/code/game/jobs/job/marine/squad_info.dm
@@ -13,7 +13,7 @@
 		update_all_squad_info()
 	if(squad_info_data["total_mar"] != count) //updates for new marines
 		update_free_mar()
-		if(squad_leader && squad_info_data["pltsgt"]["name"] != squad_leader.real_name)
+		if(squad_leader && squad_info_data["sctsgt"]["name"] != squad_leader.real_name)
 			update_squad_leader()
 	var/list/data = squad_info_data.Copy()
 	data["squad"] = name
@@ -29,7 +29,7 @@
 /datum/squad/proc/get_leadership(mob/user)
 	var/mob/living/carbon/human/H = user
 	if (squad_leader && H.name == squad_leader.name)
-		return "pltsgt"
+		return "sctsgt"
 	else
 		for(var/fireteam in fireteams)
 			var/mob/living/carbon/human/ftl = fireteam_leaders[fireteam]
@@ -58,7 +58,7 @@
 			var/target_marine = params["target_marine"]
 			var/target_team = params["target_ft"]
 
-			if (islead != "pltsgt")
+			if (islead != "sctsgt")
 				return
 
 			var/mob/living/carbon/human/target = get_marine_from_name(target_marine)
@@ -72,7 +72,7 @@
 		if ("unassign_ft")
 			var/target_marine = params["target_marine"]
 
-			if (islead != "pltsgt")
+			if (islead != "sctsgt")
 				return
 
 			var/mob/living/carbon/human/target = get_marine_from_name(target_marine)
@@ -85,7 +85,7 @@
 		if ("demote_ftl")
 			var/target_team = params["target_ft"]
 
-			if (islead != "pltsgt")
+			if (islead != "sctsgt")
 				return
 
 			unassign_ft_leader(target_team, FALSE, TRUE)
@@ -96,7 +96,7 @@
 			var/target_marine = params["target_marine"]
 			var/target_team = params["target_ft"]
 
-			if (islead != "pltsgt")
+			if (islead != "sctsgt")
 				return
 
 			var/mob/living/carbon/human/target = get_marine_from_name(target_marine)
@@ -108,7 +108,7 @@
 
 //used once on first opening
 /datum/squad/proc/update_all_squad_info()
-	squad_info_data["pltsgt"] = list()
+	squad_info_data["sctsgt"] = list()
 	update_squad_leader()
 	squad_info_data["fireteams"] = list()
 	var/i = 1
@@ -120,14 +120,14 @@
 	squad_info_data["mar_free"] = list()
 	update_free_mar()
 
-//pltsgt update. Should always be paired up with FT or free marines update
+//sctsgt update. Should always be paired up with FT or free marines update
 /datum/squad/proc/update_squad_leader()
 	var/obj/item/card/id/ID = null
 	if(squad_leader)
 		ID = squad_leader.get_idcard()
-	squad_info_data["pltsgt"]["name"] = squad_leader ? squad_leader.real_name : "None"
-	squad_info_data["pltsgt"]["refer"] = squad_leader ? "\ref[squad_leader]" : null
-	squad_info_data["pltsgt"]["paygrade"] = ID ? get_paygrades(ID.paygrade, 1) : ""
+	squad_info_data["sctsgt"]["name"] = squad_leader ? squad_leader.real_name : "None"
+	squad_info_data["sctsgt"]["refer"] = squad_leader ? "\ref[squad_leader]" : null
+	squad_info_data["sctsgt"]["paygrade"] = ID ? get_paygrades(ID.paygrade, 1) : ""
 
 //fireteam and TL update
 /datum/squad/proc/update_fireteam(team)
@@ -173,7 +173,7 @@
 				if(JOB_SQUAD_TEAM_LEADER)
 					rank = "SqSgt"
 				if(JOB_SQUAD_LEADER)
-					rank = "PltSgt"
+					rank = "SctSgt"
 				if(JOB_SQUAD_RTO)
 					rank = "RTO"
 				else
@@ -252,7 +252,7 @@
 					if(JOB_SQUAD_TEAM_LEADER)
 						rank = "SqSgt"
 					if(JOB_SQUAD_LEADER)
-						rank = "PltSgt"
+						rank = "SctSgt"
 					if(JOB_SQUAD_RTO)
 						rank = "RTO"
 					else
@@ -301,7 +301,7 @@
 					if(JOB_SQUAD_TEAM_LEADER)
 						rank = "SqSgt"
 					if(JOB_SQUAD_LEADER)
-						rank = "PltSgt"
+						rank = "SctSgt"
 					if(JOB_SQUAD_RTO)
 						rank = "RTO"
 					else

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -11,8 +11,8 @@
 	var/sub_leader
 
 /datum/squad_type/marine_squad
-	name = "Platoon"
-	lead_name = "Platoon Sergeant"
+	name = "Section"
+	lead_name = "Section Sergeant"
 	lead_icon = "leader"
 	sub_squad = "Squad"
 	sub_leader = "Squad Sergeant"

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -701,7 +701,7 @@
 			old_lead.comm_title = "SG"
 		if(JOB_SQUAD_LEADER)
 			if(!leader_killed)
-				old_lead.comm_title = "PltSgt"
+				old_lead.comm_title = "SctSgt"
 		if(JOB_SQUAD_RTO)
 			old_lead.comm_title = "RTO"
 		if(JOB_MARINE_RAIDER)

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -259,7 +259,7 @@
 		list("SG", "hudsquad_gun"),
 		list("Spc", "hudsquad_spec"),
 		list("SqSgt", "hudsquad_tl"),
-		list("PltSgt", "hudsquad_leader"),
+		list("SctSgt", "hudsquad_leader"),
 		list("RTO", "hudsquad_rto"),
 	)
 

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -467,13 +467,13 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/uscm/leader
-	name = "USCM Platoon Sergeant"
+	name = "USCM Section Sergeant"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
 	rank = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_0)
-	role_comm_title = "PltSgt"
+	role_comm_title = "SctSgt"
 	minimum_age = 27
 	skills = /datum/skills/SL
 
@@ -569,14 +569,14 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/uscm/leader_equipped
-	name = "USCM Platoon Sergeant (Equipped)"
+	name = "USCM Section Sergeant (Equipped)"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP)
 	assignment = JOB_SQUAD_LEADER
 	rank = JOB_SQUAD_LEADER
 	paygrades = list(PAY_SHORT_ME7 = JOB_PLAYTIME_TIER_0)
-	role_comm_title = "PltSgt"
+	role_comm_title = "SctSgt"
 	minimum_age = 27
 	skills = /datum/skills/SL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Changes the platoon sergeant to be section sergeant, as well as corrects some of the job descriptions to match.

# Explain why it's good for the game
The size of the main game mode, as previously discussed in the discord, is not actually a full platoon but a section of the platoon. So, by referencing the existence of this sub-element of the platoon, it should help players get more in the mindset that they are not a full detail and instead are operating under strength.

# Changelog

:cl:
qol: Platoon Sergeant is now called Section Sergeant
qol: Squad Sergeant description now references the Section Sergeant properly
spellcheck: Fixed a typo in the corpsman description that implies they are part of a squad, not a section or platoon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
