### PR TITLE
Minor ADS-C tweaks

### DIFF
--- a/code/modules/vehicles/hardpoints/primary/aa_cannon.dm
+++ b/code/modules/vehicles/hardpoints/primary/aa_cannon.dm
@@ -35,3 +35,9 @@
 		GUN_FIREMODE_AUTOMATIC,
 	)
 	fire_delay = 0.02 SECONDS
+
+/obj/item/hardpoint/primary/aa_quadcannon/set_bullet_traits()
+	..()
+	LAZYADD(traits_to_give, list(
+		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff)
+	))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Gives the quad-cannon rounds IFF.

# Explain why it's good for the game

Accidently vaporizing a marine with quad-20mms, whilst funny, isn't exactly fun for _both_ parties. This remedies that by giving the rounds the IFF passthrough thing that most other vehicle rounds possess

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: The ADS-C will no longer turn someone into swiss cheese if they stand in it's line of fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
