### PR TITLE
Light CN20 Adjustment, axes leftover FS issues

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -423,16 +423,17 @@
 		xeno_creature.AddComponent(/datum/component/status_effect/interference, 10, 10)
 		xeno_creature.blinded = TRUE
 	else
-		creature.apply_damage(12, TOX)
-		creature.apply_damage(2, BRAIN)
-		lungs.take_damage(2)
+		creature.apply_damage(18, TOX)
+		creature.apply_damage(0.75, BRAIN)
+		creature.apply_damage(1, OXY)
+		lungs.take_damage(1)
 
 	creature.SetEarDeafness(max(creature.ear_deaf, floor(effect_amt*1.5))) //Paralysis of hearing system, aka deafness
 	if(!xeno_creature) //Eye exposure damage
 		to_chat(creature, SPAN_DANGER("Your eyes sting. You can't see!"))
 		creature.SetEyeBlind(floor(effect_amt/3))
 
-		eyes.take_damage(2)
+		eyes.take_damage(1)
 	if(human_creature && creature.coughedtime < world.time && !creature.stat) //Coughing/gasping
 		creature.coughedtime = world.time + 1.5 SECONDS
 		if(prob(50))
@@ -440,7 +441,7 @@
 		else
 			creature.emote("gasp")
 
-	var/stun_chance = 20
+	var/stun_chance = 10
 	if(xeno_affecting)
 		stun_chance = 35
 	if(prob(stun_chance))

--- a/code/modules/admin/game_master/extra_buttons/fire_support_menu.dm
+++ b/code/modules/admin/game_master/extra_buttons/fire_support_menu.dm
@@ -2,7 +2,7 @@
 
 //Various ordnance selections
 #define ORDNANCE_OPTIONS list("Banshee Missile", "CN-20 Missile", "Harpoon Missile", "Keeper Missile", "Napalm Missile", "Thermobaric Missile", "Widowmaker Missile", "Laser", "Minirocket", "Incendiary Minirocket",  "Sentry Drop", "GAU-21", "Heavy GAU-21", "High Explosive", "Incendiary", "Cluster", "High Explosive","Nerve Gas OB", "Incendiary", "Fragmentation", "Flare",  "Nerve Gas Mortar")
-#define MISSILE_ORDNANCE list("Banshee Missile", "CN-20 Missile", "Harpoon Missile", "Keeper Missile", "Napalm Missile", "Thermobaric Missile", "Widowmaker Missile")
+#define MISSILE_ORDNANCE list("Banshee Missile", "Harpoon Missile", "Keeper Missile", "Napalm Missile", "Thermobaric Missile", "Widowmaker Missile")
 #define ORBITAL_ORDNANCE list("High Explosive OB", "Incendiary OB", "Cluster OB")
 #define MORTAR_ORDNANCE list("High Explosive Shell", "Incendiary Shell", "Fragmentation Shell", "Flare Shell")
 #define CHEMICAL_ORDNANCE list("CN-20 Missile", "Nerve Gas OB", "Nerve Gas Shell")

--- a/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
+++ b/code/modules/cm_marines/equipment/mortar/mortar_shells.dm
@@ -64,7 +64,7 @@
 	icon_state = "mortar_ammo_inc"
 
 /obj/item/mortar_shell/nerve/detonate(turf/T)
-	explosion(T, 0, 2, 4, 7, explosion_cause_data = cause_data)
+	cell_explosion(T, 65, 95, EXPLOSION_FALLOFF_SHAPE_LINEAR, null, null)
 	spawn(5)
 		var/datum/effect_system/smoke_spread/cn20/cn20 = new()
 		cn20.set_up(5, 0, T, null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes CN20 do additional TOX damage, plus OXY damage, in exchange for a lowering of BRAIN damage, EYE damage, and a bit less of a stun.

Tested, works fine

Also axes old leftover CN-20 missile from FS missiles menu that shouldn't be there, which was missed from the CN20 Fire Support PR (speedmerged :sob:)

Also-also slightly reworks the nerve-gas mortar shell to do less HE damage, will still mess you up but won't explode your ass (since it's a chemical shell)

# Explain why it's good for the game

 Reasoning is that CN20 as currently works is kind of, from a player perspective, sucky. You just immediately become a cripple and can't really participate without either eternal med injections of Peri/IA, or have to get medevac'd ( a thing we do rarely let's be truly honest here)

This should keep CN20 very lethal with exposure, but also give you some time to quickly throw your mask on in case you're in the cloud already. Also means you're less likely to receive round-destroying braindamage


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: CN20 does OXY damage too, now.
balance: CN20 slightly redone. More TOX, less BRAIN, less EYE, new OXY damage. CN Mortar does less direct explosive damage.
del: Removed old "CN-20 Missile" reference from FS menu that shouldn't be in the missiles menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
