### PR TITLE
Fixes the rest of the missed Section Sergeant related things

### DIFF
--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -826,10 +826,10 @@
 		id.access.Remove(squad_one_access, squad_two_access)
 
 	for(var/obj/item/device/radio/headset/cycled_headset in H)
-		if(!("Platoon Sergeant" in cycled_headset.tracking_options))
+		if(!("Section Sergeant" in cycled_headset.tracking_options))
 			continue
 
-		cycled_headset.locate_setting = cycled_headset.tracking_options["Platoon Sergeant"]
+		cycled_headset.locate_setting = cycled_headset.tracking_options["Section Sergeant"]
 
 /datum/squad/proc/assign_ft_leader(fireteam, mob/living/carbon/human/H, upd_ui = TRUE)
 	if(fireteam_leaders[fireteam])
@@ -843,10 +843,10 @@
 		to_chat(H, FONT_SIZE_HUGE(SPAN_BLUE("You were assigned as [fireteam] Team Leader.")))
 
 	for(var/obj/item/device/radio/headset/cycled_headset in H)
-		if(!("Platoon Sergeant" in cycled_headset.tracking_options))
+		if(!("Section Sergeant" in cycled_headset.tracking_options))
 			continue
 
-		cycled_headset.locate_setting = cycled_headset.tracking_options["Platoon Sergeant"]
+		cycled_headset.locate_setting = cycled_headset.tracking_options["Section Sergeant"]
 
 /datum/squad/proc/unassign_ft_leader(fireteam, clear_group_id, upd_ui = TRUE)
 	if(!fireteam_leaders[fireteam])

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -21,7 +21,7 @@
 
 	var/list/inbuilt_tracking_options = list(
 		"Platoon Commander" = TRACKER_PLTCO,
-		"Platoon Sergeant" = TRACKER_SL,
+		"Section Sergeant" = TRACKER_SL,
 		"Squad Sergeant" = TRACKER_FTL,
 		"Landing Zone" = TRACKER_LZ
 	)
@@ -410,8 +410,8 @@
 /obj/item/device/radio/headset/almayer/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 
-	if((user == user.assigned_squad?.fireteam_leaders["SQ1"] || user == user.assigned_squad?.fireteam_leaders["SQ2"]) && ("Platoon Sergeant" in tracking_options))
-		locate_setting = tracking_options["Platoon Sergeant"]
+	if((user == user.assigned_squad?.fireteam_leaders["SQ1"] || user == user.assigned_squad?.fireteam_leaders["SQ2"]) && ("Section Sergeant" in tracking_options))
+		locate_setting = tracking_options["Section Sergeant"]
 		return
 
 	if(((user in user.assigned_squad?.fireteams["SQ1"]) || (user in user.assigned_squad?.fireteams["SQ2"])) && ("Squad Sergeant" in tracking_options))
@@ -614,7 +614,7 @@
 
 	inbuilt_tracking_options = list(
 		"Platoon Commander" = TRACKER_PLTCO,
-		"Platoon Sergeant" = TRACKER_ASL,
+		"Section Sergeant" = TRACKER_ASL,
 		"Landing Zone" = TRACKER_LZ
 	)
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -383,12 +383,12 @@
 			if(!current_squad)
 				return TRUE
 
-			var/input = tgui_input_text(user, "Please write a message to announce to the squad:", "Squad Message")
+			var/input = tgui_input_text(user, "Please write a message to announce to the section:", "Section Message")
 			if(!input)
 				return TRUE
 
 			current_squad.send_message(input, 1) //message, adds username
-			current_squad.send_maptext(input, "Platoon Message:")
+			current_squad.send_maptext(input, "Section Message:")
 			visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Message '[input]' sent to all Marines of platoon '[current_squad]'.")]")
 			log_overwatch("[key_name(user)] sent '[input]' to platoon [current_squad].")
 
@@ -405,14 +405,14 @@
 			if(!current_squad)
 				return TRUE
 
-			var/input = tgui_input_text(user, "Please write a message to announce to the Platoon leader:", "SL Message")
+			var/input = tgui_input_text(user, "Please write a message to announce to the Section Leader:", "SL Message")
 			if(!input)
 				return TRUE
 
 			current_squad.send_message(input, 1, 1) //message, adds username, only to leader
-			current_squad.send_maptext(input, "Platoon Sergeant Message:", 1)
-			visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Message '[input]' sent to Platoon Sergeant [current_squad.squad_leader] of platoon '[current_squad]'.")]")
-			log_overwatch("[key_name(user)] sent '[input]' to Platoon Sergeant [current_squad.squad_leader] of squad [current_squad].")
+			current_squad.send_maptext(input, "Section Sergeant Message:", 1)
+			visible_message("[icon2html(src, viewers(src))] [SPAN_BOLDNOTICE("Message '[input]' sent to Section Sergeant [current_squad.squad_leader] of platoon '[current_squad]'.")]")
+			log_overwatch("[key_name(user)] sent '[input]' to Section Sergeant [current_squad.squad_leader] of squad [current_squad].")
 
 			var/comm_paygrade = user.get_paygrade()
 
@@ -438,7 +438,7 @@
 					current_squad.send_maptext(current_squad.secondary_objective, "Secondary Objective:")
 
 		if("set_primary")
-			var/input = sanitize_control_chars(stripped_input(usr, "What will be the squad's primary objective?", "Primary Objective"))
+			var/input = sanitize_control_chars(stripped_input(usr, "What will be the section's primary objective?", "Primary Objective"))
 			if(current_squad && input)
 				current_squad.primary_objective = "[input] ([worldtime2text()])"
 				current_squad.send_message("Your primary objective has been changed to '[input]'. See Status pane for details.")
@@ -448,7 +448,7 @@
 				return TRUE
 
 		if("set_secondary")
-			var/input = sanitize_control_chars(stripped_input(usr, "What will be the squad's secondary objective?", "Secondary Objective"))
+			var/input = sanitize_control_chars(stripped_input(usr, "What will be the section's secondary objective?", "Secondary Objective"))
 			if(input)
 				current_squad.secondary_objective = input + " ([worldtime2text()])"
 				current_squad.send_message("Your secondary objective has been changed to '[input]'. See Status pane for details.")
@@ -477,7 +477,7 @@
 			switch(z_hidden)
 				if(HIDE_NONE)
 					z_hidden = HIDE_ALMAYER
-					to_chat(user, "[icon2html(src, usr)] [SPAN_NOTICE("Marines on the Almayer are now hidden.")]")
+					to_chat(user, "[icon2html(src, usr)] [SPAN_NOTICE("Marines on the deployed vessel are now hidden.")]")
 				if(HIDE_ALMAYER)
 					z_hidden = HIDE_GROUND
 					to_chat(user, "[icon2html(src, usr)] [SPAN_NOTICE("Marines on the ground are now hidden.")]")

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -641,7 +641,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/m41aMK1(new_human.back), WEAR_IN_BACK)
 
 /datum/equipment_preset/uscm/leader_equipped/random
-	name = "USCM Platoon Sergeant (Equipped Random)"
+	name = "USCM Section Sergeant (Equipped Random)"
 
 /datum/equipment_preset/uscm/leader_equipped/random/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine(new_human), WEAR_BODY)

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -204,7 +204,7 @@ const MainDashboard = (props) => {
           icon="envelope"
           onClick={() => act('message')}
         >
-          MESSAGE SQUAD
+          MESSAGE SECTION
         </Button>
         <Button
           inline
@@ -212,7 +212,7 @@ const MainDashboard = (props) => {
           icon="person"
           onClick={() => act('sl_message')}
         >
-          MESSAGE SQUAD LEADER
+          MESSAGE SECTION LEADER
         </Button>
       </Box>
     </Section>
@@ -244,7 +244,7 @@ const RoleTable = (props) => {
     <Table m="1px" fontSize="12px" bold>
       <Table.Row>
         <Table.Cell textAlign="center" p="4px">
-          Platoon Sergeant
+          Section Sergeant
         </Table.Cell>
         <Table.Cell collapsing p="4px">
           Squad Sergeants
@@ -322,7 +322,7 @@ const SquadMonitor = (props) => {
     a = a.role;
     b = b.role;
     const roleValues = {
-      'Platoon Sergeant': 10,
+      'Section Sergeant': 10,
       'Squad Sergeant': 9,
       'Weapons Specialist': 8,
       Smartgunner: 7,

--- a/tgui/packages/tgui/interfaces/SquadInfo.tsx
+++ b/tgui/packages/tgui/interfaces/SquadInfo.tsx
@@ -34,7 +34,7 @@ interface FireTeams {
 }
 
 interface SquadProps {
-  pltsgt?: SquadLeadEntry;
+  sctsgt?: SquadLeadEntry;
   fireteams: FireTeams;
   mar_free: SquadMarineEntry[];
   total_mar: number;
@@ -44,7 +44,7 @@ interface SquadProps {
   squad: string;
   partial_squad_ref: string;
   squad_color: string;
-  is_lead: 'pltsgt' | 'SQ1' | 'SQ2' | 0;
+  is_lead: 'sctsgt' | 'SQ1' | 'SQ2' | 0;
   objective: { primary?: string; secondary?: string };
 }
 
@@ -101,7 +101,7 @@ const FireTeamLead = (props: {
       </Flex.Item>
       <Flex.Item>
         {assignedFireteamLead.name !== 'Not assigned' &&
-          data.is_lead === 'pltsgt' && <Button icon="xmark" onClick={demote} />}
+          data.is_lead === 'sctsgt' && <Button icon="xmark" onClick={demote} />}
       </Flex.Item>
     </Flex>
   );
@@ -166,7 +166,7 @@ const FireTeam = (props: { readonly sqsgt: string }) => {
                   <TableCell className="RoleCell">Role</TableCell>
                   <TableCell className="RankCell">Rank</TableCell>
                   <TableCell className="MemberCell">Member</TableCell>
-                  {data.is_lead === 'pltsgt' && (
+                  {data.is_lead === 'sctsgt' && (
                     <TableCell className="ActionCell">
                       {props.sqsgt === 'Unassigned' ? 'Assign FT' : 'Actions'}
                     </TableCell>
@@ -234,7 +234,7 @@ const FireTeamMember = (props: {
       <TableCell>{props.member.paygrade}</TableCell>
       <TableCell>{props.member.name}</TableCell>
 
-      {data.is_lead === 'pltsgt' && (
+      {data.is_lead === 'sctsgt' && (
         <TableCell>
           <Stack fill justify="center">
             {props.team === 'Unassigned' && (
@@ -290,8 +290,8 @@ export const SquadInfo = () => {
         <Flex fill={1} justify="space-around" direction="column">
           <Flex.Item>
             <Section
-              title={`${data.squad} Platoon Sergeant: ${
-                data.pltsgt?.name ?? 'None'
+              title={`${data.squad} Section Sergeant: ${
+                data.sctsgt?.name ?? 'None'
               }`}
             >
               <SquadObjectives />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adjusts the overwatch console to reference section sergeants/leaders instead of platoon or squad leaders.
Also fixes the squad info window when clicking on the tracker as the section sarge

May require finessing in the future to account for UPP forces still being considered a platoon rather than a section but I'm tired and spite only gets me so far with coding.

# Explain why it's good for the game

Oversights from prior PR's that changed things in how the section names were handled.
Makes it so section sarges can properly move people between squads or promote someone as an acting SL for the teams

# Testing Photographs and Procedure
Compiles, works as intended on local instances

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Section sergeants can once more use their squad info window to swap people between squads or assign acting SL's to the two teams
ui: Overwatch console properly references sections and section leaders in the buttons now instead of squads or platoons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
