### PR TITLE
Adjusts tools the surgical case can hold.

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -322,6 +322,9 @@
 		/obj/item/tool/surgery/scalpel,
 		/obj/item/tool/surgery/hemostat,
 		/obj/item/tool/surgery/retractor,
+		/obj/item/tool/surgery/FixOVein,
+		/obj/item/tool/surgery/surgical_line,
+		/obj/item/tool/surgery/synthgraft,
 	)
 
 /obj/item/storage/surgical_case/regular


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

As the title says, adjusts the list of surgery tools the corpsman surgical case can hold to be a little more varied. Namely, it can now store FixOvein, surgical line and synthgraft alongside the typical selection it comes with. No change to storage capacity, still only holds three.

# Explain why it's good for the game

Gives corpsmans somewhere to store any fixovein tools they find colony-side without sacrificing bag-space elsewhere. Also makes sense given the comparative size of the tools that they would be able to fit in the case in place of one of the tools.

# Testing Photographs and Procedure
Compiled without issue on local.

# Changelog

:cl:
balance: Surgical case is capable of storing three other basic surgical tools outwith the three it comes with. No change to storage space made.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
