### PR TITLE
Alternate fence buff approach

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -62,7 +62,7 @@
 		tforce = 40
 	else if(isobj(AM))
 		var/obj/item/I = AM
-		tforce = I.throwforce
+		tforce = I.throwforce/5 //Adjust higher if needed to stop knife-throwing bampots
 	health = max(0, health - tforce)
 	healthcheck()
 

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -41,7 +41,7 @@
 	if(Proj.ammo.damage_type == HALLOSS || Proj.damage <= 0 || ammo_flags == AMMO_ENERGY)
 		return 0
 
-	health -= Proj.damage * 0.3
+	health -= Proj.damage * 0.02
 	..()
 	healthcheck()
 	return 1
@@ -62,7 +62,7 @@
 		tforce = 40
 	else if(isobj(AM))
 		var/obj/item/I = AM
-		tforce = I.throwforce/5 //Adjust higher if needed to stop knife-throwing bampots
+		tforce = I.throwforce/10 //Adjust higher if needed to stop knife-throwing bampots
 	health = max(0, health - tforce)
 	healthcheck()
 
@@ -167,6 +167,17 @@
 		SPAN_NOTICE("You start cutting through [src] with [W]."))
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 25, 1)
 		if(do_after(user, 30 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
+			playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
+			user.visible_message(SPAN_NOTICE("[user] cuts through [src] with [W]."),
+			SPAN_NOTICE("You cut through [src] with [W]."))
+			cut_grille()
+		return
+
+	if(istype(W, /obj/item/attachable/bayonet) && get_dist(src, user) < 2)
+		user.visible_message(SPAN_NOTICE("[user] starts cutting through [src] with [W]."),
+		SPAN_NOTICE("You start cutting through [src] with [W]."))
+		playsound(src.loc, 'sound/items/Wirecutter.ogg', 25, 1)
+		if(do_after(user, 210 * user.get_skill_duration_multiplier(SKILL_CONSTRUCTION), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 25, 1)
 			user.visible_message(SPAN_NOTICE("[user] cuts through [src] with [W]."),
 			SPAN_NOTICE("You cut through [src] with [W]."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Makes knife-throwing at fences much, **MUCH** more ineffective, taking much more than ten throws now to break through. Similarly, it takes upwards of 60 shots from a rifle directly impacting a fence to knock it down.
As a caveat, bayonets can be used to cut fences down in a pinch, but it is **VERY** slow compared to the actual tool.

# Explain why it's good for the game

![mwehehe-cat](https://github.com/user-attachments/assets/3c335191-db6b-4935-9b3d-a8f6b72b8611)


# Testing Photographs and Procedure

Tested plenty locally, works as intended. Compiles without issue too.


# Changelog

:cl:
qol: Fences made harder to take down by marines/humans without the proper tools
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
