### PR TITLE
De-USCMifies the berets

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -240,47 +240,47 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 	path = /obj/item/clothing/head/beanie/tan
 
 /datum/gear/headwear/uscm/beret_green
-	display_name = "USCM beret, green"
+	display_name = "Beret, green"
 	path = /obj/item/clothing/head/beret/cm/green
 
 /datum/gear/headwear/uscm/beret_tan
-	display_name = "USCM beret, tan"
+	display_name = "Beret, tan"
 	path = /obj/item/clothing/head/beret/cm/tan
 
 /datum/gear/headwear/uscm/beret_black
-	display_name = "USCM beret, black"
+	display_name = "Beret, black"
 	path = /obj/item/clothing/head/beret/cm/black
 
 /datum/gear/headwear/uscm/beret_white
-	display_name = "USCM beret, white"
+	display_name = "Beret, white"
 	path = /obj/item/clothing/head/beret/cm/white
 
 /datum/gear/headwear/uscm/beret_alpha
-	display_name = "USCM beret, red flash"
+	display_name = "Beret, red flash"
 	path = /obj/item/clothing/head/beret/cm/alpha
 
 /datum/gear/headwear/uscm/beret_bravo
-	display_name = "USCM beret, yellow flash"
+	display_name = "Beret, yellow flash"
 	path = /obj/item/clothing/head/beret/cm/bravo
 
 /datum/gear/headwear/uscm/beret_charlie
-	display_name = "USCM beret, purple flash"
+	display_name = "Beret, purple flash"
 	path = /obj/item/clothing/head/beret/cm/charlie
 
 /datum/gear/headwear/uscm/beret_delta
-	display_name = "USCM beret, blue flash"
+	display_name = "Beret, blue flash"
 	path = /obj/item/clothing/head/beret/cm/delta
 
 /datum/gear/headwear/uscm/beret_echo
-	display_name = "USCM beret, green flash"
+	display_name = "Beret, green flash"
 	path = /obj/item/clothing/head/beret/cm/echo
 
 /datum/gear/headwear/uscm/beret_foxtrot
-	display_name = "USCM beret, brown flash"
+	display_name = "Beret, brown flash"
 	path = /obj/item/clothing/head/beret/cm/foxtrot
 
 /datum/gear/headwear/uscm/beret_intel
-	display_name = "USCM beret, black flash"
+	display_name = "Beret, black flash"
 	path = /obj/item/clothing/head/beret/cm/intel
 
 /datum/gear/headwear/uscm/boonie_olive

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -54,7 +54,7 @@
 
 /obj/item/clothing/head/beret/cm
 	name = "\improper Beret"
-	desc = "A hat typically worn by the French. Occasionally they find their way into the hands of marines with nothing better to spend their money on."
+	desc = "A hat typically worn by the French. Occasionally they find their way into the hands of people with nothing better to spend their money on."
 	icon = 'icons/obj/items/clothing/cm_hats.dmi'
 	icon_state = "beret"
 	item_icons = list(

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -53,8 +53,8 @@
 	icon_state = "beanietan"
 
 /obj/item/clothing/head/beret/cm
-	name = "\improper USCM beret"
-	desc = "A hat typically worn by the field-officers of the USCM. Occasionally they find their way down the ranks into the hands of squad-leaders and decorated grunts."
+	name = "\improper Beret"
+	desc = "A hat typically worn by the French. Occasionally they find their way into the hands of marines with nothing better to spend their money on."
 	icon = 'icons/obj/items/clothing/cm_hats.dmi'
 	icon_state = "beret"
 	item_icons = list(
@@ -85,41 +85,32 @@
 	icon_state = "beret_green"
 
 /obj/item/clothing/head/beret/cm/alpha
-	desc = "Often found atop heads, slightly less found on those still attached."
 	icon_state = "beret_alpha"
 
 /obj/item/clothing/head/beret/cm/bravo
-	desc = "It has quite a lot of debris on it, the person wearing this probably moves less than a wall."
 	icon_state = "beret_bravo"
 
 /obj/item/clothing/head/beret/cm/charlie
-	desc = "Still has some morning toast crumbs on it."
 	icon_state = "beret_charlie"
 
 /obj/item/clothing/head/beret/cm/delta
-	desc = "Hard to consider protection, but these types of people don't seek protection."
 	icon_state = "beret_delta"
 
 /obj/item/clothing/head/beret/cm/echo
-	desc = "Tightly Woven, as it should be."
 	icon_state = "beret_echo"
 
 /obj/item/clothing/head/beret/cm/foxtrot
-	desc = "Looks and feels starched, cold to the touch."
 	icon_state = "beret_foxtrot"
 
 /obj/item/clothing/head/beret/cm/intel
-	desc = "Looks more intellegent than the person wearing it."
 	icon_state = "beret_intel"
 
 /obj/item/clothing/head/beret/cm/white/civilian
 	name = "White Beret"
-	desc = "A nice fashionable beret, popular with executives."
 	icon_state = "s_beret"
 
 /obj/item/clothing/head/beret/cm/black/civilian
 	name = "Black Beret"
-	desc = "A nice fashionable beret, popular with executives."
 	icon_state = "beret_black"
 
 


### PR DESCRIPTION
# About the pull request
Removes any mention of the berets being in any way related to the USCM.
# Explain why it's good for the game
Marines don't get berets, but they're also the nicest looking hat in the game, and a lot of people wear them. In my opinion making them something they bought with their own money is a superior alternative to removing them.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/623a6032-40b1-4c71-beee-52f59ee13b50)
![image](https://github.com/user-attachments/assets/908f01ff-00ae-43c7-bdac-3454d5ce6a67)

</details>

# Changelog
:cl: Ediblebomb
spellcheck: Removed any mention of the USCM from the berets' name and description.
/:cl: