### PR TITLE
Ports Dying Light from PVP CM

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -302,7 +302,7 @@
 	/// Factor of duration between acid progression
 	var/acid_delay = 1
 	/// How much fuel the acid drains from the flare every acid tick
-	var/flare_damage = 500
+	var/flare_damage = 600
 	var/barricade_damage = 40
 	var/in_weather = FALSE
 
@@ -311,7 +311,7 @@
 	name = "weak acid"
 	acid_delay = 2.5 //250% delay (40% speed)
 	barricade_damage = 20
-	flare_damage = 150
+	flare_damage = 180
 	icon_state = "acid_weak"
 
 //Superacid
@@ -319,7 +319,7 @@
 	name = "strong acid"
 	acid_delay = 0.4 //40% delay (250% speed)
 	barricade_damage = 100
-	flare_damage = 1875
+	flare_damage = 2250
 	icon_state = "acid_strong"
 
 /obj/effect/xenomorph/acid/Initialize(mapload, atom/target)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -304,14 +304,14 @@
 	desc = "A red USCM issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = SIZE_SMALL
 	light_power = 2
-	light_range = 5
+	light_range = 7
 	icon_state = "flare"
 	item_state = "flare"
 	actions = list() //just pull it manually, neckbeard.
 	raillight_compatible = 0
 	can_be_broken = FALSE
 	var/burnt_out = FALSE
-	var/fuel = 0
+	var/fuel = 16 MINUTES
 	var/fuel_rate = AMOUNT_PER_TIME(1 SECONDS, 1 SECONDS)
 	var/on_damage = 7
 	var/ammo_datum = /datum/ammo/flare
@@ -329,7 +329,6 @@
 
 /obj/item/device/flashlight/flare/Initialize()
 	. = ..()
-	fuel = rand(9.5 MINUTES, 10.5 MINUTES)
 	set_light_color(flame_tint)
 
 /obj/item/device/flashlight/flare/update_icon()
@@ -364,8 +363,27 @@
 
 /obj/item/device/flashlight/flare/process(delta_time)
 	fuel -= fuel_rate * delta_time
+	flare_burn_down()
 	if(fuel <= 0 || !on)
 		burn_out()
+
+/obj/item/device/flashlight/flare/proc/flare_burn_down() //Controls the way in which flares slowly die out. Needs to be overriden by children, or they will be forced to use this light behavior.
+	switch(fuel) //The code belows controls the timing on a flares burn out, and the corresponding reduction in effective range.
+		if(15.25 MINUTES to 16 MINUTES)
+			set_light_range(7)
+		if(14.5 MINUTES to 15.24 MINUTES)
+			set_light_range(6)
+		if(6.5 MINUTES to 14.49 MINUTES)
+			set_light_range(5)
+		if(5.0 MINUTES to 6.49 MINUTES)
+			set_light_range(4)
+		if(3.5 MINUTES to 4.99 MINUTES)
+			set_light_range(3)
+		if(2.0 MINUTES to 3.49 MINUTES)
+			set_light_range(2)
+		if(0 MINUTES to 1.99 MINUTES)
+			set_light_range(1)
+			set_light_power(0.5) // A power of 2 results in no light at all, while .5 results in a small light.
 
 // Causes flares to stop with a rotation offset for visual purposes
 /obj/item/device/flashlight/flare/animation_spin(speed = 5, loop_amount = -1, clockwise = TRUE, sections = 3, angular_offset = 0, pixel_fuzz = 0)
@@ -452,10 +470,14 @@
 	icon_state = "" //No sprite
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	show_flame = FALSE
+	light_range = 7
 
 /obj/item/device/flashlight/flare/on/illumination/Initialize()
 	. = ..()
-	fuel = rand(4.5 MINUTES, 5.5 MINUTES) // Half the duration of a flare, but justified since it's invincible
+	fuel = rand(5.0 MINUTES, 6.0 MINUTES) // Approximately half the effective duration of a flare, but justified since it's invincible
+
+/obj/item/device/flashlight/flare/on/illumination/flare_burn_down() // Empty proc to override parent.
+	return
 
 /obj/item/device/flashlight/flare/on/illumination/update_icon()
 	return
@@ -474,12 +496,29 @@
 	anchored = TRUE//can't be picked up
 	ammo_datum = /datum/ammo/flare/starshell
 	show_flame = FALSE
+	light_range = 6
 
 /obj/item/device/flashlight/flare/on/starshell_ash/Initialize(mapload, ...)
 	if(mapload)
 		return INITIALIZE_HINT_QDEL
 	. = ..()
-	fuel = rand(30 SECONDS,	60 SECONDS)
+	fuel = rand(6.0 MINUTES, 6.5 MINUTES)
+
+/obj/item/device/flashlight/flare/on/starshell_ash/flare_burn_down() // Starshell's own burn_down curve, overrides parent flare.
+	switch(fuel)
+		if(6.0 MINUTES to 6.5 MINUTES)
+			set_light_range(6)
+		if(2.5 MINUTES to 5.99 MINUTES)
+			set_light_range(5)
+		if(2.0 MINUTES to 2.49 MINUTES)
+			set_light_range(4)
+		if(1.5 MINUTES to 1.99 MINUTES)
+			set_light_range(3)
+		if(1.0 MINUTES to 1.49 MINUTES)
+			set_light_range(2)
+		if(0 MINUTES to 0.99 MINUTES)
+			set_light_range(1)
+			set_light_power(0.5)
 
 /obj/item/device/flashlight/flare/on/illumination/chemical
 	name = "chemical light"
@@ -531,6 +570,7 @@
 	item_state = "cas_flare"
 	layer = ABOVE_FLY_LAYER
 	ammo_datum = /datum/ammo/flare/signal
+	light_range = 5
 	var/faction = ""
 	var/datum/cas_signal/signal
 	var/activate_message = TRUE
@@ -540,6 +580,9 @@
 /obj/item/device/flashlight/flare/signal/Initialize()
 	. = ..()
 	fuel = rand(160 SECONDS, 200 SECONDS)
+
+/obj/item/device/flashlight/flare/signal/flare_burn_down() // Empty proc to override parent.
+	return
 
 /obj/item/device/flashlight/flare/signal/attack_self(mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -603,12 +603,12 @@
 
 /obj/item/storage/box/m94
 	name = "\improper M94 marking flare pack"
-	desc = "A packet of twenty one M94 Marking Flares. Carried by USCM soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp."
+	desc = "A packet of fourteen M94 Marking Flares. Carried by USCM soldiers to light dark areas that cannot be reached with the usual TNR Shoulder Lamp."
 	icon_state = "m94"
 	icon = 'icons/obj/items/storage/packets.dmi'
 	w_class = SIZE_MEDIUM
-	storage_slots = 21
-	max_storage_space = 21
+	storage_slots = 14
+	max_storage_space = 14
 	can_hold = list(/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare/signal)
 
 /obj/item/storage/box/m94/fill_preset_inventory()
@@ -624,7 +624,7 @@
 
 /obj/item/storage/box/m94/signal
 	name = "\improper M89-S signal flare pack"
-	desc = "A packet of twenty one M89-S Signal Marking Flares."
+	desc = "A packet of fourteen M89-S Signal Marking Flares."
 	icon_state = "m89"
 
 /obj/item/storage/box/m94/signal/fill_preset_inventory()

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -252,7 +252,7 @@
 	icon_state = "secure_crate"
 
 /obj/structure/largecrate/supply/supplies/flares
-	name = "Flare supply crate (x525)"
+	name = "Flare supply crate (x320)"
 	desc = "A supply crate containing two crates of flares."
 	supplies = list(/obj/item/ammo_box/magazine/misc/flares = 2)
 

--- a/code/modules/projectiles/ammo_boxes/misc_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/misc_boxes.dm
@@ -97,7 +97,7 @@
 	var/flare_amount = 0
 	for(var/obj/item/storage/box/m94/flare_box in contents)
 		flare_amount += length(flare_box.contents)
-	flare_amount = floor(flare_amount / 20) //10 packs, 20 flares each, maximum total of 10 flares we can throw out
+	flare_amount = floor(flare_amount / 14) //10 packs, 14 flares each, maximum total of 10 flares we can throw out
 	return flare_amount
 
 /obj/item/ammo_box/magazine/misc/flares/process_burning(datum/cause_data/flame_cause_data)

--- a/code/modules/projectiles/guns/flare_gun.dm
+++ b/code/modules/projectiles/guns/flare_gun.dm
@@ -126,6 +126,9 @@
 	fired_flare.visible_message(SPAN_WARNING("\A [fired_flare] bursts into brilliant light in the sky!"))
 	fired_flare.invisibility = INVISIBILITY_MAXIMUM
 	fired_flare.mouse_opacity = FALSE
+	fired_flare.fuel = 3 MINUTES
+	fired_flare.light_range = 6
+	fired_flare.light_power = 3
 	playsound(user.loc, fire_sound, 50, 1)
 
 	var/obj/effect/flare_light/light_effect = new (fired_flare, fired_flare.light_range, fired_flare.light_power, fired_flare.light_color)
@@ -146,7 +149,7 @@
 	desc = "You are not supposed to see this. Please report it."
 	icon_state = "" //No sprite
 	invisibility = INVISIBILITY_MAXIMUM
-	light_system = STATIC_LIGHT
+	light_system = MOVABLE_LIGHT
 
 /obj/effect/flare_light/Initialize(mapload, light_range, light_power, light_color)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Ports https://github.com/cmss13-devs/cmss13/pull/7582 from PVP CM. Original PR by [MaximusRexCM](https://github.com/MaximusRexCM)

Also nerfs flare packets storage from 3 rows to 2 (21 -> 14) to compensate. Flare pouch and flare gun belt remain unchanged.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Flares burning down is super cool, and flares also lasting longer was part of the reason I made pr #100 in the first place.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/ac75b92f-43ed-44f3-b6b6-2797e834d62b)

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: MaximusRexCM, Private Tristan
add: Ports Dying Light flares from PVP CM!
balance: Increased flare duration from a variable 9.5 --> 10.5 minute length to 16 minutes flat.
balance: Flares start out strong (7 radius) and burn down to nothingness.
balance: Increased flare_damage from acid by 20% across the board.
balance: Starshell ash fuel variance changed from (4.5 to 6.0) minutes ----> (6.0 to 6.5) minute variance.
balance: Starshell ash starts out semi-bright (6 radius) and burns down to nothingness.
balance: Flare Mortars now have a static 7 tile radius , and variably last from 5 to 6 minutes.
balance: Flare gun unique-action now produces a static 7 tile radius light for 3 minutes. Slightly lower luminosity than normal.
code: Implemented a new proc, flare_burn_down, and incorporated it into process(delta_time).
balance: Flare packets only hold 14 flares (from 21) to compensate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
