### PR TITLE
UPP Heavy armour internal-storage fix

### DIFF
--- a/code/modules/clothing/suits/marine_armor/ert.dm
+++ b/code/modules/clothing/suits/marine_armor/ert.dm
@@ -279,13 +279,6 @@
 	flags_inventory = BLOCKSHARPOBJ
 	flags_armor_protection = BODY_FLAG_CHEST|BODY_FLAG_GROIN|BODY_FLAG_ARMS|BODY_FLAG_LEGS
 
-/obj/item/clothing/suit/storage/marine/faction/UPP/heavy/Initialize()
-	. = ..()
-	pockets.bypass_w_limit = list(
-		/obj/item/ammo_magazine/minigun,
-		/obj/item/ammo_magazine/pkp,
-		)
-
 /obj/item/clothing/suit/storage/marine/faction/UPP/light
 	name = "\improper 6B72-03 pattern UPP armor"
 	desc = "Vintage UPP armor system Vadasz. Provides basic ballistic/shrapnel protection for armor crew or rear line forces with wraparound soft armor and ceramic composite chestplate. Lightweight, but lacking protection class and coverage. Still issued to the Territorial Guard and People's Armed Police tactical teams, and utilized by some spetznaz."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Lets the heavy UPP armour store the same contents that the medium rig can.

# Explain why it's good for the game

There's little gain to picking the heavy over the medium besides its appearance and the armour coverage over the arms, there was even _less_ reason to pick it when you couldn't store rifle magazines or similar in its internal storage. This addresses that.


# Changelog

:cl:
fix: Lets the UPP heavy armour rig store rifle magazines and such
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
