### PR TITLE
makes CPR not give you bad advice

### DIFF
--- a/code/game/objects/items/tools/experimental_tools.dm
+++ b/code/game/objects/items/tools/experimental_tools.dm
@@ -170,22 +170,6 @@
 			pdcell.use(pump_cost)
 			update_icon()
 			return
-		else if(H.is_revivable() && H.stat == DEAD)
-			if(H.cpr_cooldown < world.time)
-				H.revive_grace_period += 7 SECONDS
-				H.visible_message(SPAN_NOTICE("<b>\The [src]</b> automatically performs <b>CPR</b> on <b>[H]</b>."))
-			else
-				H.visible_message(SPAN_NOTICE("<b>\The [src]</b> fails to perform CPR on <b>[H]</b>."))
-				if(prob(50))
-					var/obj/limb/E = H.get_limb("chest")
-					E.fracture(100)
-			H.cpr_cooldown = world.time + 7 SECONDS
-			pdcell.use(pump_cost)
-			update_icon()
-			return
-		else
-			end_cpr()
-			return PROCESS_KILL
 
 /obj/item/tool/portadialysis
 	name = "portable dialysis machine"

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -1,4 +1,3 @@
-/mob/living/carbon/human/var/cpr_cooldown
 /mob/living/carbon/human/var/cpr_attempt_timer
 /mob/living/carbon/human/attack_hand(mob/living/carbon/human/attacking_mob)
 	if(..())
@@ -47,25 +46,14 @@
 
 			cpr_attempt_timer = world.time + HUMAN_STRIP_DELAY * attacking_mob.get_skill_duration_multiplier(SKILL_MEDICAL)
 			if(do_after(attacking_mob, HUMAN_STRIP_DELAY * attacking_mob.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_ALL, BUSY_ICON_GENERIC, src, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
+				src.affected_message(attacking_mob,
+					SPAN_HELPFUL("You feel a <b>breath of fresh air</b> enter your lungs. It feels good."),
+					SPAN_HELPFUL("You <b>perform CPR</b> on <b>[src]</b>."),
+					SPAN_NOTICE("<b>[attacking_mob]</b> performs <b>CPR</b> on <b>[src]</b>."))
 				if(stat != DEAD)
 					var/suff = min(getOxyLoss(), 10) //Pre-merge level, less healing, more prevention of dieing.
 					apply_damage(-suff, OXY)
 					updatehealth()
-					src.affected_message(attacking_mob,
-						SPAN_HELPFUL("You feel a <b>breath of fresh air</b> enter your lungs. It feels good."),
-						SPAN_HELPFUL("You <b>perform CPR</b> on <b>[src]</b>. Repeat at least every <b>7 seconds</b>."),
-						SPAN_NOTICE("<b>[attacking_mob]</b> performs <b>CPR</b> on <b>[src]</b>."))
-				if(is_revivable() && stat == DEAD)
-					if(cpr_cooldown < world.time)
-						revive_grace_period += 7 SECONDS
-						attacking_mob.visible_message(SPAN_NOTICE("<b>[attacking_mob]</b> performs <b>CPR</b> on <b>[src]</b>."),
-							SPAN_HELPFUL("You perform <b>CPR</b> on <b>[src]</b>."))
-						balloon_alert(attacking_mob, "you perform cpr")
-					else
-						attacking_mob.visible_message(SPAN_NOTICE("<b>[attacking_mob]</b> fails to perform CPR on <b>[src]</b>."),
-							SPAN_HELPFUL("You <b>fail</b> to perform <b>CPR</b> on <b>[src]</b>. Incorrect rhythm. Do it <b>slower</b>."))
-						balloon_alert(attacking_mob, "incorrect rhythm. do it slower")
-					cpr_cooldown = world.time + 7 SECONDS
 			cpr_attempt_timer = 0
 			return 1
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -46,7 +46,7 @@
 
 			cpr_attempt_timer = world.time + HUMAN_STRIP_DELAY * attacking_mob.get_skill_duration_multiplier(SKILL_MEDICAL)
 			if(do_after(attacking_mob, HUMAN_STRIP_DELAY * attacking_mob.get_skill_duration_multiplier(SKILL_MEDICAL), INTERRUPT_ALL, BUSY_ICON_GENERIC, src, INTERRUPT_MOVED, BUSY_ICON_MEDICAL))
-				src.affected_message(attacking_mob,
+				affected_message(attacking_mob,
 					SPAN_HELPFUL("You feel a <b>breath of fresh air</b> enter your lungs. It feels good."),
 					SPAN_HELPFUL("You <b>perform CPR</b> on <b>[src]</b>."),
 					SPAN_NOTICE("<b>[attacking_mob]</b> performs <b>CPR</b> on <b>[src]</b>."))


### PR DESCRIPTION
# About the pull request
Makes CPR not tell you to do it way too slowly, also rips out some code we don't use.
# Explain why it's good for the game
CPR not giving you bad advice is nice, I just ripped out the code because it did nothing.
# Changelog
:cl:
spellcheck: Removes the warning to CPR slower than you actually have to.
/:cl: