### PR TITLE
Prime Roll, Tutorial, & Player Weight Change

### DIFF
--- a/code/datums/entities/player.dm
+++ b/code/datums/entities/player.dm
@@ -503,7 +503,6 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 	set waitfor=0
 	WAIT_DB_READY
 	load_player_data_info(get_player_from_key(ckey))
-	check_discord_link()
 
 /client/proc/load_player_data_info(datum/entity/player/player)
 	if(ckey != player.ckey)
@@ -521,25 +520,6 @@ BSQL_PROTECT_DATUM(/datum/entity/player)
 		player_data.load_byond_account_age()
 	player_data.save()
 	record_login_triplet(player.ckey, address, computer_id)
-	player_data.sync()
-
-/client/proc/check_discord_link()
-	var/datum/view_record/discord_link/current_link = locate() in DB_VIEW(/datum/view_record/discord_link, DB_COMP("player_id", DB_EQUALS, player_data.id))
-
-	if(!current_link)
-
-		if(player_data.discord_link_id != null)
-			player_data.discord_link_id = null
-			player_data.save()
-			player_data.sync()
-
-		return
-
-	if(player_data.discord_link_id == current_link.id)
-		return
-
-	player_data.discord_link_id = current_link.id
-	player_data.save()
 	player_data.sync()
 
 /datum/entity/player/proc/check_ban(computer_id, address, is_telemetry)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -41,7 +41,7 @@
 	/// If TRUE, this job will spawn w/ a cryo emergency kit during evac/red alert
 	var/gets_emergency_kit = TRUE
 
-	/// Whether or not linking your discord account can let you get prime priority for this role
+	/// Whether or not having enough playtime will allow you to primeroll
 	var/prime_priority = FALSE
 
 /datum/job/New()

--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -176,9 +176,9 @@ I hope it's easier to tell what the heck this proc is even doing, unlike previou
 
 		var/new_bonus = 0
 		switch(cycled_unassigned.client.get_total_human_playtime()) //+1 for new players, +2 for really new players
-			if(0 to 2 HOURS)
+			if(0 to 5 HOURS)
 				new_bonus = 2
-			if(2 HOURS to 5 HOURS)
+			if(5 HOURS to 8 HOURS)
 				new_bonus = 1
 
 		var/streak_bonus = max(get_client_stat(cycled_unassigned.client, PLAYER_STAT_UNASSIGNED_ROUND_STREAK) - 2, 0) //+1 per missed round after 2

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -686,7 +686,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 
 	var/host_bypass = FALSE
 	if(user.client?.admin_holder?.check_for_rights(R_HOST))
-		host_bypass = TRUE
+		host_bypass = FALSE
 
 	var/HTML = "<body>"
 	HTML += "<tt><center>"
@@ -763,7 +763,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 					b_color = "orange"
 					priority_text = "LOW"
 
-			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_priority || !user.client?.player_data?.discord_link_id || user.client?.get_total_human_playtime() < JOB_PLAYTIME_TIER_1))
+			if(j == PRIME_PRIORITY && !host_bypass && (!job.prime_priority || user.client?.get_total_human_playtime() < JOB_PLAYTIME_TIER_2))
 				continue
 
 			HTML += "<a class='[j == cur_priority ? b_color : "inactive"]' href='?_src_=prefs;preference=job;task=input;text=[job.title];target_priority=[j];'>[priority_text]</a>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -686,7 +686,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 
 	var/host_bypass = FALSE
 	if(user.client?.admin_holder?.check_for_rights(R_HOST))
-		host_bypass = FALSE
+		host_bypass = TRUE
 
 	var/HTML = "<body>"
 	HTML += "<tt><center>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -163,10 +163,11 @@
 				to_chat(src, SPAN_WARNING("Sorry, you cannot late join during [SSticker.mode.name]. You have to start at the beginning of the round. You may observe or try to join as an alien, if possible."))
 				return
 
-			if(client.player_data?.playtime_loaded && (client.get_total_human_playtime() < CONFIG_GET(number/notify_new_player_age)) && !length(client.prefs.completed_tutorials))
-				if(tgui_alert(src, "You have little playtime and haven't completed any tutorials. Would you like to go to the tutorial menu?", "Tutorial", list("Yes", "No")) == "Yes")
-					tutorial_menu()
-					return
+			// commented out tutorial due to its lack of relevance on pve
+			//if(client.player_data?.playtime_loaded && (client.get_total_human_playtime() < CONFIG_GET(number/notify_new_player_age)) && !length(client.prefs.completed_tutorials))
+				//if(tgui_alert(src, "You have little playtime and haven't completed any tutorials. Would you like to go to the tutorial menu?", "Tutorial", list("Yes", "No")) == "Yes")
+					//tutorial_menu()
+					//return
 
 			LateChoices()
 


### PR DESCRIPTION
Modifies prime rolls, tutorials, and player weight changes.

Prime rolls: Prime rolls now are given to anyone with 25 human hours.
Tutorial: Tutorial now no longer suggests you play it if you're new (commented it out)
Weight changes: New players keep their weighted rolling for longer (2 for 0-5, 1 for 5-8) as rounds can be long and if it happens to be a miss round or something comes up, they miss a lot of weighting. Pluys 


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Changes prime rolls to now work with anyone with 25 human hours
qol: Tutorial no longer is suggested to new players
qol: New players now have +2 weight between 0-5 hours and +1 weight for 5-8 hours.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
