### PR TITLE
Makes PMC and RMC Smartguns use 10x28, buffs damage.

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -181,6 +181,50 @@
 	target.AddComponent(/datum/component/status_effect/toxic_buildup)
 	knockback(target, fired_proj, max_range = 2)
 
+// PMC Smartgun
+
+/datum/ammo/bullet/rifle/heavy/dirty
+	name = "irradiated 10x28 bullet"
+	damage = 60
+	debilitate = list(0,0,0,3,0,0,0,1) // Stun,knockdown,knockout,irradiate,stutter,eyeblur,drowsy,agony
+	headshot_state = HEADSHOT_OVERLAY_MEDIUM
+	shrapnel_chance = SHRAPNEL_CHANCE_TIER_7
+	penetration = ARMOR_PENETRATION_TIER_3
+	accuracy = HIT_ACCURACY_TIER_3
+	shell_speed = AMMO_SPEED_TIER_6
+	effective_range_max = 10
+	damage_falloff = DAMAGE_FALLOFF_TIER_9
+
+/datum/ammo/bullet/rifle/heavy/dirty/ap
+	name = "irradiated armor-piercing 10x28 bullet"
+	debilitate = list(0,0,0,3,0,0,0,1)
+	damage = 45
+	penetration = ARMOR_PENETRATION_TIER_8
+
+// RMC Smartgun
+
+/datum/ammo/bullet/rifle/heavy/holo_target //Royal marines smartgun bullet has only diff between regular ammo is this one does holostacks and less damage
+	name = "holo-targeting 10x28 bullet"
+	damage = 50
+	/// inflicts this many holo stacks per bullet hit
+	var/holo_stacks = 15
+	/// modifies the default cap limit of 100 by this amount
+	var/bonus_damage_cap_increase = 0
+	/// multiplies the default drain of 5 holo stacks per second by this amount
+	var/stack_loss_multiplier = 1
+
+/datum/ammo/bullet/rifle/heavy/holo_target/on_hit_mob(mob/hit_mob, obj/projectile/bullet)
+	. = ..()
+	hit_mob.AddComponent(/datum/component/bonus_damage_stack, holo_stacks, world.time, bonus_damage_cap_increase, stack_loss_multiplier)
+
+/datum/ammo/bullet/rifle/heavy/holo_target/ap
+	name = "holo-targetting armor-piercing 10x28 bullet"
+	icon_state = "bullet"
+
+	accuracy = HIT_ACCURACY_TIER_2
+	damage = 35
+	penetration = ARMOR_PENETRATION_TIER_8
+
 // Custom Specialist M4RA rounds
 
 /datum/ammo/bullet/rifle/heavy/spec

--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -189,10 +189,6 @@
 	debilitate = list(0,0,0,3,0,0,0,1) // Stun,knockdown,knockout,irradiate,stutter,eyeblur,drowsy,agony
 	headshot_state = HEADSHOT_OVERLAY_MEDIUM
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_7
-	penetration = ARMOR_PENETRATION_TIER_3
-	accuracy = HIT_ACCURACY_TIER_3
-	shell_speed = AMMO_SPEED_TIER_6
-	effective_range_max = 10
 	damage_falloff = DAMAGE_FALLOFF_TIER_9
 
 /datum/ammo/bullet/rifle/heavy/dirty/ap

--- a/code/modules/gear_presets/pmc.dm
+++ b/code/modules/gear_presets/pmc.dm
@@ -996,7 +996,6 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/marine/smartgunner/veteran/pmc, WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/veteran/pmc, WEAR_HANDS)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/pmc/gunner, WEAR_HEAD)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m56_goggles/no_nightvision(new_human), WEAR_EYES)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/rmc, WEAR_FEET)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/pmc/leader, WEAR_FACE)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/black_vest, WEAR_ACCESSORY)
@@ -1009,6 +1008,8 @@ list("POUCHES (CHOOSE 2)", 0, null, null, null),
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/magazine/pistol/large/vp78, WEAR_R_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full, WEAR_L_STORE)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/smartgunner/pmc/full, WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/m56_goggles/no_nightvision(new_human), WEAR_EYES)
+
 
 /datum/equipment_preset/pmc/pmc_gunner/get_antag_clothing_equipment()
 	return list(

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -25,7 +25,7 @@
 	var/requires_battery = TRUE
 	/// Whether the smartgun requires a harness to use
 	var/requires_harness = TRUE
-	ammo = /datum/ammo/bullet/smartgun
+	ammo = /datum/ammo/bullet/rifle/heavy
 	actions_types = list(
 		/datum/action/item_action/smartgun/toggle_accuracy_improvement,
 		/datum/action/item_action/smartgun/toggle_ammo_type,
@@ -677,8 +677,8 @@
 	desc = "The actual firearm in the 4-piece M56D Smartgun System. If you have this, you're about to bring some serious pain to anyone in your way.\nYou may toggle firing restrictions by using a special action.\nAlt-click it to open the feed cover and allow for reloading."
 	current_mag = /obj/item/ammo_magazine/smartgun/dirty
 	ammo = /obj/item/ammo_magazine/smartgun/dirty
-	ammo_primary = /datum/ammo/bullet/smartgun/dirty//Toggled ammo type
-	ammo_secondary = /datum/ammo/bullet/smartgun/dirty/armor_piercing///Toggled ammo type
+	ammo_primary = /datum/ammo/bullet/rifle/heavy/dirty //Toggled ammo type
+	ammo_secondary = /datum/ammo/bullet/rifle/heavy/dirty/ap ///Toggled ammo type
 	flags_gun_features = GUN_WY_RESTRICTED|GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY
 
 /obj/item/weapon/gun/smartgun/dirty/Initialize(mapload, ...)
@@ -752,8 +752,8 @@
 	desc = "The actual firearm in the 2-piece L56A2 Smartgun System. This Variant is used by the Three World Empires Royal Marines Commando units.\nYou may toggle firing restrictions by using a special action.\nAlt-click it to open the feed cover and allow for reloading."
 	current_mag = /obj/item/ammo_magazine/smartgun/holo_targetting
 	ammo = /obj/item/ammo_magazine/smartgun/holo_targetting
-	ammo_primary = /datum/ammo/bullet/smartgun/holo_target //Toggled ammo type
-	ammo_secondary = /datum/ammo/bullet/smartgun/holo_target/ap ///Toggled ammo type
+	ammo_primary = /datum/ammo/bullet/rifle/heavy/holo_target //Toggled ammo type
+	ammo_secondary = /datum/ammo/bullet/rifle/heavy/holo_target/ap ///Toggled ammo type
 	flags_gun_features = GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/twe_guns.dmi'
 	icon_state = "magsg"

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -108,14 +108,14 @@
 	name = "irradiated smartgun drum"
 	desc = "What at first glance appears to be a standard 500 round M56 Smartgun drum, is actually a drum loaded with irradiated rounds, providing an extra 'oomph' to to its bullets. The magazine itself is slightly modified to only fit in M56D or M56T smartguns, and is marked with a red X."
 	icon_state = "m56_drum_dirty"
-	default_ammo = /datum/ammo/bullet/smartgun/dirty
+	default_ammo = /datum/ammo/bullet/rifle/heavy/dirty
 	gun_type = /obj/item/weapon/gun/smartgun
 
 /obj/item/ammo_magazine/smartgun/holo_targetting
 	name = "holotargetting smartgun drum"
 	desc = "Holotargetting rounds for use in the royal marines commando L56A2 smartgun."
 	icon_state = "m56_drum"
-	default_ammo = /datum/ammo/bullet/smartgun/holo_target
+	default_ammo = /datum/ammo/bullet/rifle/heavy/holo_target
 	gun_type = /obj/item/weapon/gun/smartgun/rmc
 //-------------------------------------------------------
 //Flare gun. Close enough?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
PMC smartgun:
Regular damage from 40 to 60 (Regular SG does 55)
AP from 30 to 45 (Regular AP does 40)

RMC Smartgun:
Damage from 30 to 50 (Regular SG does 55)
AP from 20 to 30 (Regular AP does 40)

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
#376 only changed the regular smartgun ammo, meaning that PMC's SG (Which used to have more damage + irradiation) now did 15 less damage per shot than a regular old SG, which is a bit strange seeing how PMCs are meant to have a better kit than marines.

And I did RMC too because they've got high tech or whatever, smartgun goes pew pew

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: PMC and RMC smartguns now use 10x28mm instead of snowflake SG bullets, their damage has also been increased.
fix: PMC smartgunner loadout now properly spawns with its imager, allowing IFF to be used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
