### PR TITLE
makes christmas less lrp

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -13,6 +13,8 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 		if(G.display_name in GLOB.gear_datums_by_name)
 			log_debug("Duplicate gear datum name: [G.display_name].")
 			continue
+		if(!G.special_conditions())
+			continue
 		LAZYSET(GLOB.gear_datums_by_category[G.category], "[G.display_name] [G.cost == 1 ? "(1 point)" : "([G.cost] points)"]", G)
 		GLOB.gear_datums_by_name[G.display_name] = G
 
@@ -24,6 +26,9 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 	var/slot // Slot to equip to, if any.
 	var/list/allowed_roles   // Roles that can spawn with this item.
 	var/list/allowed_origins
+
+/datum/gear/proc/special_conditions()
+	return TRUE
 
 /datum/gear/eyewear
 	category = "Eyewear"
@@ -207,6 +212,22 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 	category = "Headwear"
 	cost = 3
 	slot = WEAR_HEAD
+
+/datum/gear/headwear/uscm/santa_hat
+	display_name = "santa hat, red"
+	path = /obj/item/clothing/head/santa
+	cost = 1
+
+/datum/gear/headwear/uscm/santa_hat/special_conditions()
+	return is_month(12) && (is_day(21) || is_day(22) || is_day(23) || is_day(24) || is_day(25) || is_day(26))
+
+/datum/gear/headwear/uscm/santa_hat_green
+	display_name = "santa hat, green"
+	path = /obj/item/clothing/head/santa/green
+	cost = 1
+
+/datum/gear/headwear/uscm/santa_hat_green/special_conditions()
+	return is_month(12) && (is_day(21) || is_day(22) || is_day(23) || is_day(24) || is_day(25) || is_day(26))
 
 /datum/gear/headwear/durag_black
 	display_name = "Durag, black"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -271,3 +271,13 @@
 	siemens_coefficient = 2
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	anti_hug = 10 //Lel
+
+/obj/item/clothing/head/santa
+	name = "\improper santa hat"
+	icon_state = "santa_hat_red"
+	item_state = "santa_hat_red"
+	desc = "Ho ho ho. Merry Christmas!"
+
+/obj/item/clothing/head/santa/green
+	icon_state = "santa_hat_green"
+	item_state = "santa_hat_green"

--- a/code/modules/decorators/christmas.dm
+++ b/code/modules/decorators/christmas.dm
@@ -7,69 +7,6 @@
 /datum/decorator/christmas/is_active_decor()
 	return is_month(12) && (is_day(21) || is_day(22) || is_day(23) || is_day(24) || is_day(25) || is_day(26))
 
-// define who is being decorated
-/datum/decorator/christmas/queen/get_decor_types()
-	return typesof(/mob/living/carbon/xenomorph/queen)
-
-// maybe we want to have screech separate from this. Also good test
-/datum/decorator/christmas/queen/screech
-	priority = DECORATOR_DAY_SPECIFIC
-
-/datum/decorator/christmas/queen/screech/decorate(mob/living/carbon/xenomorph/queen/queen)
-	if(!istype(queen))
-		return
-	queen.screech_sound_effect_list = list('sound/voice/alien_queen_xmas.ogg','sound/voice/alien_queen_xmas_2.ogg')
-
-/datum/decorator/christmas/queen/hat/decorate(mob/living/carbon/xenomorph/queen/queen)
-	if(!istype(queen))
-		return
-	//queen.icon_body = 'icons/mob/xenos_old/xenomorph_64x64_christmas.dmi'
-
-// barbed wire changes are added as a whole, so no need to split
-/datum/decorator/christmas/barbed_wire/get_decor_types()
-	return list(/obj/item/stack/barbed_wire)
-
-/datum/decorator/christmas/barbed_wire/decorate(obj/item/stack/barbed_wire/wire)
-	if(!istype(wire))
-		return
-	wire.name = "christmas wire"
-	wire.desc = "A bulbed, festive, and dangerous length of wire."
-	wire.attack_verb = list("hit", "whacked", "sliced", "festivized")
-	wire.icon = 'icons/obj/items/marine-items_christmas.dmi'
-	wire.update_icon()
-
-// helmet definition. Also only a single definition
-/datum/decorator/christmas/marine_helmet/get_decor_types()
-	return list(/obj/item/clothing/head/helmet/marine)
-
-/datum/decorator/christmas/marine_helmet/decorate(obj/item/clothing/head/helmet/marine/helmet)
-	if(!istype(helmet))
-		return
-	helmet.name = "\improper USCM [helmet.specialty] santa hat"
-	helmet.desc = "Ho ho ho, Merry Christmas!"
-	helmet.icon = 'icons/obj/items/clothing/hats.dmi'
-	helmet.icon_override = 'icons/mob/humans/onmob/head_0.dmi'
-	helmet.flags_inv_hide = HIDEEARS|HIDEALLHAIR
-	helmet.flags_marine_helmet = NO_FLAGS
-	helmet.flags_atom |= NO_SNOW_TYPE|NO_NAME_OVERRIDE
-	if(prob(50))
-		helmet.icon_state = "santa_hat_red"
-	else
-		helmet.icon_state = "santa_hat_green"
-	helmet.update_icon()
-
-// barricade definition. Also only a single definition
-// some types are not represented in that DMI, so we have to cherrypick
-/datum/decorator/christmas/barricade/get_decor_types()
-	return typesof(/obj/structure/barricade/metal) + typesof(/obj/structure/barricade/plasteel)
-
-/datum/decorator/christmas/barricade/decorate(obj/structure/barricade/barricade)
-	if(!istype(barricade))
-		return
-	barricade.wire_icon = 'icons/obj/structures/barricades_christmas.dmi'
-	barricade.update_icon()
-
-
 /// Replaces marine food dispensers contents with more festive MREs
 /datum/decorator/christmas/food
 
@@ -89,9 +26,6 @@
 		list("Metal Flask", 10, /obj/item/reagent_container/food/drinks/flask, VENDOR_ITEM_REGULAR),
 		list("USCM Flask", 5, /obj/item/reagent_container/food/drinks/flask/marine, VENDOR_ITEM_REGULAR),
 		list("W-Y Flask", 5, /obj/item/reagent_container/food/drinks/flask/weylandyutani, VENDOR_ITEM_REGULAR),
-
-		list("UTILITIES", -1, null, null),
-		list("C92 pattern 'Festivizer' decorator", 10, /obj/item/toy/festivizer, VENDOR_ITEM_REGULAR)
 	)
 
 /datum/decorator/christmas/builder_list/get_decor_types()

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -322,6 +322,9 @@ GLOBAL_LIST_EMPTY(personal_closets)
 			if(current_gear.allowed_origins && !(new_human.origin in current_gear.allowed_origins))
 				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Invalid Origin"))
 				return
+			if(!current_gear.special_conditions)
+				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Special conditions not met."))
+				return
 			new current_gear.path(closet_to_spawn_in)
 
 	//Gives ranks to the ranked

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -225,6 +225,9 @@
 			if(current_gear.allowed_origins && !(new_human.origin in current_gear.allowed_origins))
 				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Invalid Origin"))
 				return
+			if(!current_gear.special_conditions)
+				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Special conditions not met."))
+				return
 			if(!(current_gear.slot && new_human.equip_to_slot_or_del(new current_gear.path, current_gear.slot)))
 				var/obj/equipping_gear = new current_gear.path
 				new_human.equip_to_slot_or_del(equipping_gear, WEAR_IN_BACK)

--- a/code/modules/gear_presets/_select_equipment.dm
+++ b/code/modules/gear_presets/_select_equipment.dm
@@ -225,7 +225,7 @@
 			if(current_gear.allowed_origins && !(new_human.origin in current_gear.allowed_origins))
 				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Invalid Origin"))
 				return
-			if(!current_gear.special_conditions)
+			if(!current_gear.special_conditions())
 				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Special conditions not met."))
 				return
 			if(!(current_gear.slot && new_human.equip_to_slot_or_del(new current_gear.path, current_gear.slot)))
@@ -322,7 +322,7 @@ GLOBAL_LIST_EMPTY(personal_closets)
 			if(current_gear.allowed_origins && !(new_human.origin in current_gear.allowed_origins))
 				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Invalid Origin"))
 				return
-			if(!current_gear.special_conditions)
+			if(!current_gear.special_conditions())
 				to_chat(new_human, SPAN_WARNING("Custom gear [current_gear.display_name] cannot be equipped: Special conditions not met."))
 				return
 			new current_gear.path(closet_to_spawn_in)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

removes most decorators for christmas, namely wires, helmets-to-santa hats and queen ho-ho-hoing
removes festivizers from food vendors
adds santa hat to loadout but only when its christmas

# Explain why it's good for the game

no lrp is awesome


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Removes most christmas decorators, adds santa hats to loadout, available during christmas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
