### PR TITLE
Increasing Admin Sound upload limit

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -2,7 +2,7 @@
 	//SECURITY//
 	////////////
 #define TOPIC_SPAM_DELAY 2 //2 ticks is about 2/10ths of a second; it was 4 ticks, but that caused too many clicks to be lost due to lag
-#define UPLOAD_LIMIT 10485760 //Restricts client uploads to the server to 10MB //Boosted this thing. What's the worst that can happen?
+#define UPLOAD_LIMIT 20971520 //Restricts client uploads to the server to 20MB //Boosted this thing (again). What's the worst that can happen?
 #define MIN_CLIENT_VERSION 0 //Just an ambiguously low version for now, I don't want to suddenly stop people playing.
 									//I would just like the code ready should it ever need to be used.
 


### PR DESCRIPTION
Note: This is my first PR ever. Hopefully I did this right.

# About the pull request

Since YouTube has failed us, it'd be nice to have a bit more headroom in our file uploads for playing music during the round. Harry proposed potentially tripling this value (and I wouldn't be opposed to it, personally), but this is enough for longer tracks at lower bitrates.

# Explain why it's good for the game

We're currently hard-capped at 10mb for sound files. That's an awkward breakpoint when it comes to even Variable Bitrate MP3s: You get maybe 6 minutes that way. And considering our operations go for a more cinematic feel, it'd be nice to use scoring that doesn't require reconverting and compressing it from wherever you nabbed it from -- or chopping it up, god forbid.

# Testing Photographs and Procedure
Logged into my local server and tried playing a 13mb mp3. It worked. Neat!

# Changelog
:cl:
config: define UPLOAD_LIMIT value doubled (10485760 to 20971520)