### PR TITLE
auto looc mute

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -173,6 +173,8 @@ Administrative related.
 
 /datum/config_entry/flag/autooocmute
 
+/datum/config_entry/flag/autoloocmute
+
 /datum/config_entry/flag/mentor_tools // Extra tooling for mentors that might otherwise be staff only
 	config_entry_value = FALSE
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -200,6 +200,9 @@ SUBSYSTEM_DEF(ticker)
 	if(CONFIG_GET(flag/autooocmute))
 		GLOB.ooc_allowed = FALSE
 
+	if(CONFIG_GET(flag/autoloocmute))
+		GLOB.looc_allowed = FALSE
+
 	round_start_time = world.time
 
 	CHECK_TICK

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -173,6 +173,9 @@ USEALIENWHITELIST
 ## Automute the OOC channel. OOC mutes itself at round-start and unmutes itself at round-end.
 AUTOOOCMUTE
 
+## Automute the LOOC channel. LOOC mutes itself at round-start and unmutes itself at round-end.
+AUTOLOOCMUTE
+
 ## Uncomment to enable the script that posts runtimes to GitLab
 ## Before you do so, make sure to set up the required environment vars:
 ##     1. GITLAB_RUNTIMES_PID - The Project ID of the project where the issues should be posted. Found on the details page of the project, directly under the project name.


### PR DESCRIPTION
People tend to abuse LOOC on PVE a lot for its unintended purpose, ranging from asking questions/saying things that could be done in IC, to completely crowding the briefing with pink text and undermining the platoon commanders already minimal impact on the game.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
config: Auto mute LOOC config, LOOC muted by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
