### PR TITLE
Wake up, marines! (Removes salt from prepackaged MREs)

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -3429,17 +3429,14 @@
 			icon_state = "entree"
 			desc = "An MRE entree component. Contains the main course for nutrients. This one is [flavor]."
 			reagents.add_reagent("nutriment", 14)
-			reagents.add_reagent("sodiumchloride", 6)
 		if("cracker", "cheese spread", "rice onigiri", "mashed potatoes", "risotto")
 			icon_state = "side"
 			desc = "An MRE side component. Contains a side, to be eaten alongside the main. This one is [flavor]."
 			reagents.add_reagent("nutriment", 6)
-			reagents.add_reagent("sodiumchloride", 2)
 		if("biscuit", "meatballs", "pretzels", "peanuts", "sushi")
 			icon_state = "snack"
 			desc = "An MRE snack component. Contains a light snack in case you weren't feeling terribly hungry. This one is [flavor]."
 			reagents.add_reagent("nutriment", 4)
-			reagents.add_reagent("sodiumchloride", 2)
 		if("spiced apples", "chocolate brownie", "sugar cookie", "coco bar", "flan", "honey flan")
 			icon_state = "dessert"
 			desc = "An MRE side component. Contains a sweet dessert, to be eaten after the main (or before, if you're rebellious). This one is [flavor]."


### PR DESCRIPTION
# About the pull request

Removes sodiumchloride (table salt) from prepackaged MRE components. Sodiumchloride contains Relaxing 1 as its sole property, which causes both uncontrollable yawning and a very slight movement slowdown.

# Explain why it's good for the game

Uncontrollable yawning is annoying and doesn't make a ton of sense as a reaction to just scarfing some pretzels. And the vendor meals don't contain salt and thus don't proc Relaxing, which has lead to a general sense of confusion around what makes this happen.

While other prepackaged foods will still contain sodiumchloride, I think that's okay. The Relaxing property does a better job of emulating the effects of eating something greasy or oily than it does eating something salty.

# Testing Photographs and Procedure

Spawned MRE components and checked their contained reagents through both the VV menu and a reagent grinder. No salt!

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/7af5c239-6008-4298-8fa8-313d14c297b8)
![image](https://github.com/user-attachments/assets/0caa088a-c400-48d9-adaf-e154369337bf)

And here's a demonstration of how disruptive yawning can be. This is during a brief:

![image](https://github.com/user-attachments/assets/367f64f5-9b10-4d4d-9873-108926a9133c)

</details>

# Changelog

:cl:
del: Removed salt from prepackaged MRE components
/:cl: