### PR TITLE
Allows more stuff in APC storage container

### DIFF
--- a/code/modules/vehicles/interior/interactable/vehicle_locker.dm
+++ b/code/modules/vehicles/interior/interactable/vehicle_locker.dm
@@ -35,7 +35,8 @@
 									/obj/item/device/motiondetector,
 									/obj/item/ammo_magazine/hardpoint,
 									/obj/item/tool/weldpack,
-									/obj/item/ammo_box/magazine
+									/obj/item/ammo_box/magazine,
+									/obj/item/storage/box
 									)
 	flags_atom |= USES_HEARING
 

--- a/code/modules/vehicles/interior/interactable/vehicle_locker.dm
+++ b/code/modules/vehicles/interior/interactable/vehicle_locker.dm
@@ -35,7 +35,7 @@
 									/obj/item/device/motiondetector,
 									/obj/item/ammo_magazine/hardpoint,
 									/obj/item/tool/weldpack,
-									/obj/item/ammo_box/magazine,
+									/obj/item/ammo_box,
 									/obj/item/storage/box
 									)
 	flags_atom |= USES_HEARING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

title

# Explain why it's good for the game

Theres a lot of things that, I think should reasonably be able to fit inside the APC storage boxes but don't, sentry boxes, Smartgun loose ammo boxes, this PR lets them and a lot of other things able to be placed inside https://i.imgur.com/GUJX7ch.png


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: SpartanBobby
add: Changed the APC storage container to be able to fit more stuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
