### PR TITLE
Remove Non-Crit OD Coffee Jitter

### DIFF
--- a/code/modules/reagents/chemistry_reagents/drink.dm
+++ b/code/modules/reagents/chemistry_reagents/drink.dm
@@ -376,7 +376,6 @@
 /datum/reagent/drink/coffee/on_mob_life(mob/living/M)
 	. = ..()
 	if(!.) return
-	M.make_jittery(5)
 	if(adj_temp > 0 && holder)
 		holder.remove_reagent("frostoil", 10*REAGENTS_METABOLISM)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Coffee no longer causes jitter unless it is a critical OD.

# Explain why it's good for the game

1.05 Cups of Coffee should not cause the same effect as chestbursting, neurotoxin, etc.
# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: Coffee only makes a human jittery at a critical-OD threshold, not from a consecutive > 20 units.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
