### PR TITLE
Adds some liquid versions of advanced medications for corpsmen to pick from

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -355,6 +355,11 @@ GLOBAL_LIST_INIT(cm_vending_chemical_medic, list(
 		list("Pill Bottle (Nitrogen-Water)", 40, /obj/item/storage/pill_bottle/nitrogenwater, null, VENDOR_ITEM_REGULAR),
 		list("Pill Bottle (Dexalin+)", 40, /obj/item/storage/pill_bottle/dexalinplus, null, VENDOR_ITEM_REGULAR),
 		list("Pill Bottle (Iron)", 40, /obj/item/storage/pill_bottle/iron, null, VENDOR_ITEM_REGULAR),
+
+		list("LIQUID BOTTLES", 0, null, null, null),
+		list("Liquid Bottle (Imidazoline-Alkysine)", 40, /obj/item/reagent_container/glass/bottle/imialk, null, VENDOR_ITEM_REGULAR),
+		list("Liquid Bottle (Meralyne-Bicardine)", 40, /obj/item/reagent_container/glass/bottle/merabica, null, VENDOR_ITEM_REGULAR),
+		list("Liquid Bottle (Kelotane-Dermaline)", 40, /obj/item/reagent_container/glass/bottle/keloderm, null, VENDOR_ITEM_REGULAR),
 	))
 
 /obj/structure/machinery/cm_vending/gear/medic_chemical

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -209,6 +209,45 @@
 	. = ..()
 	reagents.add_reagent("anti_toxin", 150)
 
+/obj/item/reagent_container/glass/bottle/imialk
+	name = "\improper Imidazoline-Alkysine bottle"
+	desc = "A small bottle of imidazoline and alkysine, used to heal brain and eye damage."
+	icon = 'icons/obj/items/chemistry.dmi'
+	icon_state = "bottle19"
+	volume = 135
+	amount_per_transfer_from_this = 135
+
+/obj/item/reagent_container/glass/bottle/imialk/Initialize()
+	. = ..()
+	reagents.add_reagent("imidazoline", 67.5)
+	reagents.add_reagent("alkysine", 67.5)
+
+/obj/item/reagent_container/glass/bottle/merabica
+	name = "\improper Meralyne-Bicaridine bottle"
+	desc = "A small bottle of meralyne and bicaridine. Rapidly heals brute damage."
+	icon = 'icons/obj/items/chemistry.dmi'
+	icon_state = "bottle17"
+	volume = 135
+	amount_per_transfer_from_this = 135
+
+/obj/item/reagent_container/glass/bottle/merabica/Initialize()
+	. = ..()
+	reagents.add_reagent("bicaridine", 67.5)
+	reagents.add_reagent("meralyne", 67.5)
+
+/obj/item/reagent_container/glass/bottle/keloderm
+	name = "\improper Kelotane-Dermaline bottle"
+	desc = "A small bottle of Kelotane & Dermaline, a pair of burn regrowth drugs."
+	icon = 'icons/obj/items/chemistry.dmi'
+	icon_state = "bottle15"
+	volume = 135
+	amount_per_transfer_from_this = 135
+
+/obj/item/reagent_container/glass/bottle/keloderm/Initialize()
+	. = ..()
+	reagents.add_reagent("kelotane", 67.5)
+	reagents.add_reagent("dermaline", 67.5)
+
 /obj/item/reagent_container/glass/bottle/mutagen
 	name = "unstable mutagen bottle"
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds IA, MB & KD liquid bottles to the corpsman advanced medications vendor.

# Explain why it's good for the game

WIth the PR that ups bottle capacity & buffs syringes is in, this goes further by offering some advanced mixed-meds options for those corpsmen who wish to wholly go pill-less in their loadout.

# Testing Photographs and Procedure
Compiled without issue, tested on local & functioning as expected.

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/2217e850-7cb3-478a-97b5-4826c010298f)

</details>


# Changelog

:cl:
add: Liquid bottle versions of IA, MB & KD are available in the corpsman advanced medications vendor
/:cl:

