### PR TITLE
Fixes inconsistences with pronouns in emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -18,6 +18,10 @@
 	var/message = ""
 	///Message displayed for audible emotes if someone's deaf. Only use this if key_third_person can't be acceptably used.
 	///ie. if someone says *medic and someone's deaf, they'd receive [X] calls for a medic! silently.,  which is not ideal.
+
+	/// Message after any alterations, like pronoun replacement for predefined emotes
+	var/msg =""
+
 	var/alt_message
 	/// Message with %t at the end to allow adding params to the message, like for mobs doing an emote relatively to something else.
 	var/message_param = ""
@@ -79,15 +83,16 @@
  *
  * Returns TRUE if it was able to run the emote, FALSE otherwise.
  */
-/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)
+/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE, prefix, keep_pronouns = FALSE)
 	. = TRUE
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
-	var/msg = select_message_type(user, message, intentional)
+	msg = select_message_type(user, message, intentional)
 	if(params && message_param)
 		msg = select_param(user, params)
-
-	//msg = replace_pronoun(user, msg)
+	//
+	if(!keep_pronouns)
+		msg	 = replace_pronoun(user, msg)
 
 	if(say_message)
 		user.say(say_message)
@@ -166,7 +171,7 @@
  * * group - The list of people that will see this emote being
  */
 /datum/emote/proc/run_langchat(mob/user, list/group)
-	user.langchat_speech(message, group, GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("emote", "langchat_small"))
+	user.langchat_speech(msg, group, GLOB.all_languages, skip_language_check = TRUE, additional_styles = list("emote", "langchat_small"))
 
 /**
  * For handling emote cooldown, return true to allow the emote to happen.
@@ -209,7 +214,7 @@
  * * msg - The string to modify.
  *
  * Returns the modified msg string.
-
+ */
 /datum/emote/proc/replace_pronoun(mob/user, msg)
 	if(findtext(msg, "their"))
 		msg = replacetext(msg, "their", user.p_their())
@@ -220,7 +225,7 @@
 	if(findtext(msg, "%s"))
 		msg = replacetext(msg, "%s", user.p_s())
 	return msg
- */
+
 /**
  * Selects the message type to override the message with.
  *

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -87,7 +87,7 @@
 	if(params && message_param)
 		msg = select_param(user, params)
 
-	msg = replace_pronoun(user, msg)
+	//msg = replace_pronoun(user, msg)
 
 	if(say_message)
 		user.say(say_message)
@@ -209,7 +209,7 @@
  * * msg - The string to modify.
  *
  * Returns the modified msg string.
- */
+
 /datum/emote/proc/replace_pronoun(mob/user, msg)
 	if(findtext(msg, "their"))
 		msg = replacetext(msg, "their", user.p_their())
@@ -220,7 +220,7 @@
 	if(findtext(msg, "%s"))
 		msg = replacetext(msg, "%s", user.p_s())
 	return msg
-
+ */
 /**
  * Selects the message type to override the message with.
  *

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -20,7 +20,7 @@
 	///ie. if someone says *medic and someone's deaf, they'd receive [X] calls for a medic! silently.,  which is not ideal.
 
 	/// Message after any alterations, like pronoun replacement for predefined emotes
-	var/msg =""
+	var/msg = ""
 
 	var/alt_message
 	/// Message with %t at the end to allow adding params to the message, like for mobs doing an emote relatively to something else.

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -56,7 +56,7 @@
 	key_third_person = "custom"
 	keybind = FALSE
 
-/datum/emote/custom/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
+/datum/emote/custom/run_emote(mob/user, params, type_override, intentional = FALSE, prefix, keep_pronouns = TRUE)
 	if(user.client && user.client.prefs.muted & MUTE_IC)
 		to_chat(user, SPAN_DANGER("You cannot emote (muted)."))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Stops the words "their/them/they", and other pronouns being swapped in the _**chatlog**_ with the equivalent of the character's pronoun/gender when they do a /me.
Langchat now shows the characters pronouns for _**predefined**_ emotes, same as the chatlog.

# Explain why it's good for the game

It is unnecessary and confusing to not be able to use these words in an emote, and to have your emote subtly changed.

# Testing Photographs and Procedure
CUSTOM EMOTE TEXT:
![image](https://github.com/user-attachments/assets/c2066f30-45bc-4b36-87e9-437358edd40d)
BEFORE:
![Screenshot 2025-01-20 020413](https://github.com/user-attachments/assets/c271f003-2a2c-4c05-a821-eaf317f15b98)
![image](https://github.com/user-attachments/assets/cc691096-00fe-4964-a019-203f39702b56)
AFTER:
![Screenshot 2025-01-20 020413](https://github.com/user-attachments/assets/bb366d4e-0b3d-4961-9932-9d4fe6d10e5e)
![image](https://github.com/user-attachments/assets/dc004452-18c9-49af-9540-aea104b0d307)
----
PREDEFINDED EMOTE TEXT:
![image](https://github.com/user-attachments/assets/0f4d4694-c79c-4247-b619-771147a40305)

BEFORE:
![image](https://github.com/user-attachments/assets/791f7f31-4b78-4bb8-80e5-168d5b4e4db1)
![image](https://github.com/user-attachments/assets/420ead10-160e-4bcb-a800-424d69232d40)

AFTER:
![image](https://github.com/user-attachments/assets/ef76e897-f16d-4f80-ba17-6fcd0defeaff)
![image](https://github.com/user-attachments/assets/60369c3f-2698-4496-bf5a-afcd85f1d286)


<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Pronouns are no longer force replaced in the chatlog output of a Me verb with the character's equivalent. No more "their" --> "her".
fix: Overhead chat now uses the character's pronouns for predefined emotes, like the chatlog already does.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
