### PR TITLE
Revert "Prop Language Randomization"

### DIFF
--- a/code/modules/gear_presets/clf.dm
+++ b/code/modules/gear_presets/clf.dm
@@ -1,6 +1,6 @@
 /datum/equipment_preset/clf
 	name = FACTION_CLF
-	languages = list(LANGUAGE_SPANISH)
+	languages = list(LANGUAGE_JAPANESE, LANGUAGE_ENGLISH)
 	assignment = JOB_CLF
 	rank = FACTION_CLF
 	paygrades = list(PAY_SHORT_REB = JOB_PLAYTIME_TIER_0)
@@ -10,7 +10,6 @@
 
 /datum/equipment_preset/clf/New()
 	. = ..()
-	languages += pick_weight(list(LANGUAGE_ENGLISH = 5, LANGUAGE_JAPANESE = 3, LANGUAGE_RUSSIAN = 2, LANGUAGE_CHINESE = 2))
 	access = get_access(ACCESS_LIST_CLF_BASE)
 
 /datum/equipment_preset/clf/load_name(mob/living/carbon/human/new_human, randomise)

--- a/code/modules/gear_presets/cmb.dm
+++ b/code/modules/gear_presets/cmb.dm
@@ -4,13 +4,12 @@
 	faction_group = list(FACTION_MARSHAL, FACTION_MARINE)
 	rank = JOB_CMB
 	idtype = /obj/item/card/id/deputy
-	languages = list(LANGUAGE_ENGLISH)
+	languages = list(LANGUAGE_ENGLISH, LANGUAGE_JAPANESE)
 	var/human_versus_human = FALSE
 	var/headset_type = /obj/item/device/radio/headset/distress/CMB/limited
 
 /datum/equipment_preset/cmb/New()
 	. = ..()
-	languages += pick_weight(list(LANGUAGE_SPANISH = 5, LANGUAGE_JAPANESE = 3, LANGUAGE_RUSSIAN = 1, LANGUAGE_CHINESE = 1))
 	access = get_access(ACCESS_LIST_UA)
 
 /datum/equipment_preset/cmb/load_name(mob/living/carbon/human/new_human, randomise)


### PR DESCRIPTION
Reverts cmss13-devs/cmss13-pve#585

props shouldnt have completely random languages, messes with more stuff than it helps. i.e. what if i want a clf who speaks english? gotta spend 5 minutes trying to rng one or add it in varedit

:cl:
code: Reverts #585
/:cl: