### PR TITLE
Being Grabbed, or in Crit stops Wandering from Brain Damage

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -260,9 +260,9 @@
 		return
 
 	if(organ_status >= ORGAN_BRUISED && prob(5 * delta_time))
-		var/dir_choice = pick(list(NORTH, SOUTH, EAST, WEST))
 		owner.drop_held_items()
-		if(!owner.buckled && owner.stat == CONSCIOUS)
+		if(!(owner.buckled || owner.pulledby) && owner.stat == CONSCIOUS && !(locate(/datum/effects/crit) in owner.effects_list))
+			var/dir_choice = pick(list(NORTH, SOUTH, EAST, WEST))
 			owner.Move(get_step(get_turf(owner), dir_choice))
 		to_chat(owner, SPAN_DANGER("Your mind wanders and goes blank for a moment..."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

1. Fixes a bug introduced in https://github.com/cmss13-devs/cmss13-pve/pull/335.
2. Makes it easier to handcuff a human, etc with brain damage if you have already grabbed them.

# Explain why it's good for the game

1. Fixes bug.
2. Mostly in line with what already occurs when secured to a roller bed, or movable chairs.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Brain damage no longer causes movements while the human is grabbed.
fix: Brain damage no longer causes movements in Critical Pain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
