### PR TITLE
Records are no longer cut off, adds record computers to all shipmaps.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -59,7 +59,7 @@
 //Runs sanitize and strip_html_simple
 //I believe strip_html_simple() is required to run first to prevent '<' from displaying as '&lt;' after sanitize() calls byond's html_encode()
 /proc/strip_html(text, limit=MAX_MESSAGE_LEN)
-	return copytext((sanitize(strip_html_simple(text))), 1, limit)
+	return copytext((sanitize(strip_html_simple(text, limit))), 1, limit)
 
 //Runs byond's sanitization proc along-side strip_html_simple
 //I believe strip_html_simple() is required to run first to prevent '<' from displaying as '&lt;' that html_encode() would cause

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2149,9 +2149,9 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 		character.flavor_texts["feet"] = flavor_texts["feet"]
 
 	if(!be_random_name)
-		character.med_record = strip_html(med_record)
-		character.sec_record = strip_html(sec_record)
-		character.gen_record = strip_html(gen_record)
+		character.med_record = strip_html(med_record, MAX_RECORDS_MESSAGE_LEN)
+		character.sec_record = strip_html(sec_record, MAX_RECORDS_MESSAGE_LEN)
+		character.gen_record = strip_html(gen_record, MAX_RECORDS_MESSAGE_LEN)
 		character.exploit_record = strip_html(exploit_record)
 
 	character.age = age

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1536,7 +1536,7 @@
 	set desc = "Sets a description which will be shown when someone examines you."
 	set category = "IC"
 
-	pose =  strip_html(input(usr, "This is [src]. \He is...", "Pose", null)  as message)
+	pose =  strip_html(input(usr, "This is [src]. \He is...", "Pose", null)  as message, MAX_FLAVOR_MESSAGE_LEN)
 
 /mob/living/carbon/human/verb/set_flavor()
 	set name = "Set Flavour Text"

--- a/maps/map_files/chapaev/chapaev.dmm
+++ b/maps/map_files/chapaev/chapaev.dmm
@@ -618,6 +618,10 @@
 /obj/structure/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/machinery/computer/secure_data{
+	dir = 8;
+	req_access = null
+	},
 /turf/open/floor/strata/multi_tiles,
 /area/golden_arrow/platoon_sergeant)
 "eY" = (
@@ -3720,13 +3724,14 @@
 /area/golden_arrow/medical)
 "Gz" = (
 /obj/structure/surface/table/reinforced/almayer_B,
-/obj/structure/machinery/computer/emails{
-	dir = 8
-	},
 /obj/item/device/flashlight/lamp/on{
 	pixel_y = 21;
 	pixel_x = 2;
 	anchored = 1
+	},
+/obj/structure/machinery/computer/skills{
+	dir = 8;
+	req_one_access = null
 	},
 /turf/open/floor/strata/floor2,
 /area/golden_arrow/platoon_sergeant)
@@ -5101,12 +5106,18 @@
 /area/golden_arrow/canteen)
 "Vd" = (
 /obj/structure/machinery/computer/crew/alt{
-	dir = 1
+	dir = 1;
+	pixel_x = -8
 	},
 /obj/structure/surface/table/almayer{
 	color = "#8B9490"
 	},
 /obj/structure/machinery/light/double,
+/obj/structure/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_x = 10;
+	req_one_access = list(240, 241, 242)
+	},
 /turf/open/floor/strata/floor3,
 /area/golden_arrow/medical)
 "Vp" = (

--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -2048,6 +2048,9 @@
 	pixel_y = 5;
 	pixel_x = -4
 	},
+/obj/structure/machinery/computer/skills{
+	req_one_access = null
+	},
 /turf/open/floor/almayer,
 /area/golden_arrow/shared_office)
 "ahk" = (

--- a/maps/map_files/rover/rover.dmm
+++ b/maps/map_files/rover/rover.dmm
@@ -2838,11 +2838,21 @@
 /obj/structure/surface/table/almayer,
 /obj/item/prop/magazine/boots/n117{
 	pixel_x = -5;
-	pixel_y = 3
+	pixel_y = -5
 	},
 /obj/item/reagent_container/food/drinks/cans/souto/lime{
 	pixel_x = 9;
 	pixel_y = 3
+	},
+/obj/structure/machinery/computer/secure_data{
+	dir = 4;
+	pixel_y = 8;
+	req_access = null
+	},
+/obj/structure/machinery/computer/skills{
+	req_one_access = null;
+	dir = 4;
+	pixel_y = -7
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/squad_one)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Raises the character limit for Set Pose from 1024 to 3072.
Fixes a small oversight in `/proc/strip_html`. This means records are no longer truncated.
Adds an employment computer to the shared office on the Golden Arrow.
Adds a security record and employment computer to the Sergeants Room on the Chapaev.
Adds a security record and employment computer to the Squad Leaders Room on the Rover.
# Explain why it's good for the game

More Soul.
Fixes bug in #647.
Makes it possible to view all the character records on every shipmap.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Added employment record computers to the Golden Arrow, Chapaev and Rover. Added security record computers to the Chapeav and Rover.
fix: Fixed record length being truncated due to an oversight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
