### PR TITLE
Disables Shoot-to-Kill by Default

### DIFF
--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_EMPTY(human_ai_brains)
 	var/action_delay_mult = 1
 
 	/// If TRUE, shoots until the target is dead. Else, stops when downed
-	var/shoot_to_kill = TRUE
+	var/shoot_to_kill = FALSE
 
 	/// Distance for view checks
 	var/view_distance = 7

--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_factions.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_factions.dm
@@ -2,7 +2,7 @@
 	/// What actual faction is this faction tied to
 	var/faction = FACTION_NEUTRAL
 	/// If FALSE, the AI will not intentionally kill enemies. The enemies may still be killed by crossfire, explosives, etc.
-	VAR_PROTECTED/shoot_to_kill = TRUE
+	VAR_PROTECTED/shoot_to_kill = FALSE
 
 	VAR_PROTECTED/list/enter_combat_lines = list()
 	VAR_PROTECTED/list/exit_combat_lines = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Prevents hostile AI enemies (xenomorphs, HAI, etc) from killing downed/critical Marines by default ("Shoot to Kill"). This can still be enabled by the GM through the "Human Faction Management Panel".

# Explain why it's good for the game

This is established precedent - enemies have always historically stopped attacking downed players. With the recent HAI changes, they now require a GM to remember to disable it if they don't want a player being downed as a death sentence for them, something that might blindside both the GM (if they don't remember or weren't informed) and the player who got attacked to death once they collapsed into crit. It's not fair to normal gameplay; if GMs want the enemies to be punishing and attack downed players, they should be the ones to make the call to enable it, not disable it.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Enemies will no longer attack downed players by default. GMs can reenable this behavior in the Human Faction Management Panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
