### PR TITLE
Adjusted rank options for the Section/Platoon

### DIFF
--- a/code/__DEFINES/job.dm
+++ b/code/__DEFINES/job.dm
@@ -23,7 +23,7 @@
 #define JOB_SQUAD_ENGI "Combat Technician"
 #define JOB_SQUAD_MEDIC "Corpsman"
 #define JOB_SQUAD_SPECIALIST "Weapons Specialist"
-#define JOB_SQUAD_TEAM_LEADER "Squad Sergeant"
+#define JOB_SQUAD_TEAM_LEADER "Squad Leader"
 #define JOB_SQUAD_SMARTGUN "Smartgunner"
 #define JOB_SQUAD_ROLES /datum/timelock/squad
 #define JOB_SQUAD_ROLES_LIST list(JOB_SQUAD_MARINE, JOB_SQUAD_LEADER, JOB_SQUAD_ENGI, JOB_SQUAD_MEDIC, JOB_SQUAD_SPECIALIST, JOB_SQUAD_SMARTGUN, JOB_SQUAD_TEAM_LEADER)

--- a/code/game/jobs/job/command/cic/staffofficer.dm
+++ b/code/game/jobs/job/command/cic/staffofficer.dm
@@ -1,6 +1,6 @@
 
-#define SECOND_LT_VARIANT "Second Lieutenant"
 #define FIRST_LT_VARIANT "First Lieutenant"
+#define SECOND_LT_VARIANT "Second Lieutenant"
 
 /datum/job/command/bridge
 	title = JOB_SO
@@ -13,7 +13,7 @@
 	gear_preset_secondary = /datum/equipment_preset/uscm_ship/so/lesser_rank
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>Your job is to conduct the briefing for the platoon, monitor the operation, and listen to your superior officers.</a> You are in charge of the platoon for the current operation and supported by your Company Command.<br>They will give your orders VIA the telephone in your office once they are ready.<br><b>You remember that you've stored your personal gear are located in your personal quarters.</b><br>Your job involves heavy roleplay and requires you to behave like an officer and to stay in character at all times."
 
-	job_options = list(FIRST_LT_VARIANT = "1stLt", SECOND_LT_VARIANT = "2ndLt")
+	job_options = list(SECOND_LT_VARIANT = "2ndLt", FIRST_LT_VARIANT = "1stLt")
 
 /datum/job/command/bridge/set_spawn_positions(count)
 	spawn_positions = so_slot_formula(count)
@@ -43,10 +43,10 @@
 	GLOB.marine_leaders[JOB_SO] -= M
 
 /datum/job/command/bridge/handle_job_options(option)
-	if(option != FIRST_LT_VARIANT)
-		gear_preset = gear_preset_secondary
-	else
+	if(option != SECOND_LT_VARIANT)
 		gear_preset = initial(gear_preset)
+	else
+		gear_preset = gear_preset_secondary
 
 OverrideTimelock(/datum/job/command/bridge, list(
 	JOB_SQUAD_ROLES = 1 HOURS
@@ -85,5 +85,5 @@ OverrideTimelock(/datum/job/command/bridge, list(
 	icon_state = "so_spawn"
 	job = /datum/job/command/bridge/ai/upp
 
-#undef SECOND_LT_VARIANT
 #undef FIRST_LT_VARIANT
+#undef SECOND_LT_VARIANT

--- a/code/game/jobs/job/marine/squad/leader.dm
+++ b/code/game/jobs/job/marine/squad/leader.dm
@@ -1,6 +1,6 @@
 
-#define SSGT_VARIANT "Staff Sergeant"
 #define GYSGT_VARIANT "Gunnery Sergeant"
+#define SSGT_VARIANT "Staff Sergeant"
 
 /datum/job/marine/leader
 	title = JOB_SQUAD_LEADER
@@ -12,13 +12,13 @@
 	gear_preset_secondary = /datum/equipment_preset/uscm/leader/lesser_rank
 	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are responsible for the men and women of your entire section.</a> Make sure they are on task, working together, and communicating. You are also in charge of communicating with command and letting them know about the situation first hand. Keep out of harm's way.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
 
-	job_options = list(GYSGT_VARIANT = "GYSGT", SSGT_VARIANT = "SSGT")
+	job_options = list(SSGT_VARIANT = "SSGT", GYSGT_VARIANT = "GYSGT")
 
 /datum/job/marine/leader/handle_job_options(option)
-	if(option != GYSGT_VARIANT)
-		gear_preset = gear_preset_secondary
-	else
+	if(option != SSGT_VARIANT)
 		gear_preset = initial(gear_preset)
+	else
+		gear_preset = gear_preset_secondary
 
 /datum/job/marine/leader/whiskey
 	title = JOB_WO_SQUAD_LEADER
@@ -75,5 +75,5 @@ OverrideTimelock(/datum/job/marine/leader, list(
 	squad = SQUAD_LRRP
 	job = /datum/job/marine/leader/ai/forecon
 
-#undef SSGT_VARIANT
 #undef GYSGT_VARIANT
+#undef SSGT_VARIANT

--- a/code/game/jobs/job/marine/squad/medic.dm
+++ b/code/game/jobs/job/marine/squad/medic.dm
@@ -1,6 +1,6 @@
 
-#define LCPL_VARIANT "Lance Corporal"
 #define CPL_VARIANT "Corporal"
+#define LCPL_VARIANT "Lance Corporal"
 
 /datum/job/marine/medic
 	title = JOB_SQUAD_MEDIC
@@ -10,9 +10,9 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/medic
 	gear_preset_secondary = /datum/equipment_preset/uscm/medic/lesser_rank
-	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You tend the wounds of your fellow Marines</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters.<br><b>You remember that you've stored your personal gear and uniform are located in your medical office.</b>"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You tend the wounds of your fellow Marines</a> and make sure they are healthy and active. You may not be a fully-fledged doctor, but you stand between life and death when it matters.<br>You might be the same rank as a squad leader, but they have precedence over you for command should the situation call upon it.<br><b>You remember that you've stored your personal gear and uniform are located in your medical office.</b>"
 
-	job_options = list(CPL_VARIANT = "CPL", LCPL_VARIANT = "LCPL")
+	job_options = list(LCPL_VARIANT = "LCPL", CPL_VARIANT = "CPL")
 
 /datum/job/marine/medic/set_spawn_positions(count)
 	for(var/datum/squad/sq in GLOB.RoleAuthority.squads)
@@ -35,10 +35,10 @@
 	return (slots*4)
 
 /datum/job/marine/medic/handle_job_options(option)
-	if(option != CPL_VARIANT)
-		gear_preset = gear_preset_secondary
-	else
+	if(option != LCPL_VARIANT)
 		gear_preset = initial(gear_preset)
+	else
+		gear_preset = gear_preset_secondary
 
 /datum/job/marine/medic/whiskey
 	title = JOB_WO_SQUAD_MEDIC
@@ -96,5 +96,5 @@
 	squad = SQUAD_LRRP
 	job = /datum/job/marine/medic/ai/forecon
 
-#undef LCPL_VARIANT
 #undef CPL_VARIANT
+#undef LCPL_VARIANT

--- a/code/game/jobs/job/marine/squad/smartgunner.dm
+++ b/code/game/jobs/job/marine/squad/smartgunner.dm
@@ -1,6 +1,6 @@
 
-#define LCPL_VARIANT "Lance Corporal"
 #define CPL_VARIANT "Corporal"
+#define LCPL_VARIANT "Lance Corporal"
 
 /datum/job/marine/smartgunner
 	title = JOB_SQUAD_SMARTGUN
@@ -11,9 +11,9 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/sg
 	gear_preset_secondary = /datum/equipment_preset/uscm/sg/lesser_rank
-	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are a specialized automatic rifleman.</a> Your task is to provide heavy weapons support for your squad.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
+	entry_message_body = "<a href='"+WIKI_PLACEHOLDER+"'>You are a specialized automatic rifleman.</a> Your task is to provide heavy weapons support for your squad.<br>You might be the same rank as a squad leader, but they have precedence over you for command should the situation call upon it.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
 
-	job_options = list(CPL_VARIANT = "CPL", LCPL_VARIANT = "LCPL")
+	job_options = list(LCPL_VARIANT = "LCPL", CPL_VARIANT = "CPL")
 
 /datum/job/marine/smartgunner/set_spawn_positions(count)
 	spawn_positions = sg_slot_formula(count)
@@ -31,10 +31,10 @@
 	return positions
 
 /datum/job/marine/smartgunner/handle_job_options(option)
-	if(option != CPL_VARIANT)
-		gear_preset = gear_preset_secondary
-	else
+	if(option != LCPL_VARIANT)
 		gear_preset = initial(gear_preset)
+	else
+		gear_preset = gear_preset_secondary
 
 /datum/job/marine/smartgunner/whiskey
 	title = JOB_WO_SQUAD_SMARTGUNNER
@@ -94,5 +94,5 @@
 	job = JOB_SQUAD_SMARTGUN_FORECON
 	squad = SQUAD_LRRP
 
-#undef LCPL_VARIANT
 #undef CPL_VARIANT
+#undef LCPL_VARIANT

--- a/code/game/jobs/job/marine/squad/standard.dm
+++ b/code/game/jobs/job/marine/squad/standard.dm
@@ -1,7 +1,7 @@
 #define STANDARD_MARINE_TO_TOTAL_SPAWN_RATIO 0.4
 
-#define PVT_VARIANT "Private"
 #define PFC_VARIANT "Private First Class"
+#define PVT_VARIANT "Private"
 
 /datum/job/marine/standard
 	title = JOB_SQUAD_MARINE
@@ -10,7 +10,7 @@
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/pfc
 	gear_preset_secondary = /datum/equipment_preset/uscm/pfc/lesser_rank
-	job_options = list(PFC_VARIANT = "PFC", PVT_VARIANT = "PVT")
+	job_options = list(PVT_VARIANT = "PVT", PFC_VARIANT = "PFC")
 
 /datum/job/marine/standard/on_config_load()
 	entry_message_body = "You are a rank-and-file <a href='[CONFIG_GET(string/wikiarticleurl)]/[URL_WIKI_MARINE_QUICKSTART]'>Soldier of your standing army</a>, and that is your strength. What you lack alone, you gain standing shoulder to shoulder with the men and women of the platoon. Ooh-rah!<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
@@ -20,10 +20,10 @@
 	spawn_positions = max((floor(count * STANDARD_MARINE_TO_TOTAL_SPAWN_RATIO)), 8)
 
 /datum/job/marine/standard/handle_job_options(option)
-	if(option != PFC_VARIANT)
-		gear_preset = gear_preset_secondary
-	else
+	if(option != PVT_VARIANT)
 		gear_preset = initial(gear_preset)
+	else
+		gear_preset = gear_preset_secondary
 
 /datum/job/marine/standard/whiskey
 	title = JOB_WO_SQUAD_MARINE
@@ -92,5 +92,5 @@
 	squad = SQUAD_LRRP
 	job = /datum/job/marine/standard/ai/rto
 
-#undef PVT_VARIANT
 #undef PFC_VARIANT
+#undef PVT_VARIANT

--- a/code/game/jobs/job/marine/squad/tl.dm
+++ b/code/game/jobs/job/marine/squad/tl.dm
@@ -1,5 +1,6 @@
 
 #define SGT_VARIANT "Sergeant"
+#define CPL_VARIANT "Corporal"
 
 /datum/job/marine/tl
 	title = JOB_SQUAD_TEAM_LEADER
@@ -8,13 +9,20 @@
 	allow_additional = 1
 	flags_startup_parameters = ROLE_ADD_TO_DEFAULT|ROLE_ADD_TO_SQUAD
 	gear_preset = /datum/equipment_preset/uscm/tl
+	gear_preset_secondary = /datum/equipment_preset/uscm/tl/lesser_rank
 	entry_message_body = "You are the <a href='"+WIKI_PLACEHOLDER+"'>Squad Leader.</a> Your task is leading the designated squad and utilize available ordnance. If the section sergeant dies, you are expected to lead in their place.<br><b>You remember that you've stored your personal gear and uniform are located in the dorm or locker rooms.</b>"
 
-	job_options = list(SGT_VARIANT = "SGT")
+	job_options = list(CPL_VARIANT = "CPL", SGT_VARIANT = "SGT")
 
 /datum/job/marine/tl/generate_entry_conditions(mob/living/carbon/human/spawning_human)
 	. = ..()
 	spawning_human.important_radio_channels += JTAC_FREQ
+
+/datum/job/marine/tl/handle_job_options(option)
+	if(option != CPL_VARIANT)
+		gear_preset = initial(gear_preset)
+	else
+		gear_preset = gear_preset_secondary
 
 /obj/effect/landmark/start/marine/tl
 	name = JOB_SQUAD_TEAM_LEADER
@@ -44,12 +52,14 @@
 /datum/job/marine/tl/ai/upp
 	title = JOB_SQUAD_TEAM_LEADER_UPP
 	gear_preset = /datum/equipment_preset/uscm/tl/upp
+	gear_preset_secondary = /datum/equipment_preset/uscm/tl/upp/lesser_rank
 
 /datum/job/marine/tl/ai/forecon
 	total_positions = 1
 	spawn_positions = 1
 	title = JOB_SQUAD_TEAM_LEADER_FORECON
 	gear_preset = /datum/equipment_preset/uscm/tl/forecon
+	gear_preset_secondary = /datum/equipment_preset/uscm/tl/forecon/lesser_rank
 
 /obj/effect/landmark/start/marine/tl/upp
 	name = JOB_SQUAD_TEAM_LEADER_UPP
@@ -62,3 +72,4 @@
 	job = /datum/job/marine/tl/ai/forecon
 
 #undef SGT_VARIANT
+#undef CPL_VARIANT

--- a/code/game/jobs/job/marine/squad_info.dm
+++ b/code/game/jobs/job/marine/squad_info.dm
@@ -133,7 +133,7 @@
 /datum/squad/proc/update_fireteam(team)
 	squad_info_data["fireteams"][team]["total"] = length(fireteams[team])
 	if(squad_info_data["fireteams"][team]["total"] < 1)
-		squad_info_data["fireteams"][team]["sqsgt"] = list()
+		squad_info_data["fireteams"][team]["sqldr"] = list()
 		squad_info_data["fireteams"][team]["mar"] = list()
 		return
 
@@ -150,14 +150,14 @@
 				if(skillcheck(H, SKILL_ENGINEER, SKILL_ENGINEER_NOVICE))
 					Eng = TRUE
 		ID = H.get_idcard()
-		squad_info_data["fireteams"][team]["sqsgt"] = list(
+		squad_info_data["fireteams"][team]["sqldr"] = list(
 							"name" = H.real_name,
 							"med" = Med,
 							"eng" = Eng,
 							"status" = H.squad_status,
 							"refer" = "\ref[H]")
 		if(ID)
-			squad_info_data["fireteams"][team]["sqsgt"] += list("paygrade" = get_paygrades(ID.paygrade, 1))
+			squad_info_data["fireteams"][team]["sqldr"] += list("paygrade" = get_paygrades(ID.paygrade, 1))
 			var/rank = ID.rank
 			switch(rank)
 				if(JOB_SQUAD_MARINE)
@@ -171,19 +171,19 @@
 				if(JOB_SQUAD_SPECIALIST)
 					rank = "Spc"
 				if(JOB_SQUAD_TEAM_LEADER)
-					rank = "SqSgt"
+					rank = "SqLdr"
 				if(JOB_SQUAD_LEADER)
 					rank = "SctSgt"
 				if(JOB_SQUAD_RTO)
 					rank = "RTO"
 				else
 					rank = ""
-			squad_info_data["fireteams"][team]["sqsgt"] += list("rank" = rank)
+			squad_info_data["fireteams"][team]["sqldr"] += list("rank" = rank)
 		else
-			squad_info_data["fireteams"][team]["sqsgt"] += list("paygrade" = "N/A")
-			squad_info_data["fireteams"][team]["sqsgt"] += list("rank" = "")
+			squad_info_data["fireteams"][team]["sqldr"] += list("paygrade" = "N/A")
+			squad_info_data["fireteams"][team]["sqldr"] += list("rank" = "")
 	else
-		squad_info_data["fireteams"][team]["sqsgt"] = list(
+		squad_info_data["fireteams"][team]["sqldr"] = list(
 							"name" = "Not assigned",
 							"paygrade" = "",
 							"rank" = "",
@@ -250,7 +250,7 @@
 					if(JOB_SQUAD_SPECIALIST)
 						rank = "Spc"
 					if(JOB_SQUAD_TEAM_LEADER)
-						rank = "SqSgt"
+						rank = "SqLdr"
 					if(JOB_SQUAD_LEADER)
 						rank = "SctSgt"
 					if(JOB_SQUAD_RTO)
@@ -299,7 +299,7 @@
 					if(JOB_SQUAD_SPECIALIST)
 						rank = "Spc"
 					if(JOB_SQUAD_TEAM_LEADER)
-						rank = "SqSgt"
+						rank = "SqLdr"
 					if(JOB_SQUAD_LEADER)
 						rank = "SctSgt"
 					if(JOB_SQUAD_RTO)

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -696,7 +696,7 @@
 		if(JOB_SQUAD_MEDIC)
 			old_lead.comm_title = "HM"
 		if(JOB_SQUAD_TEAM_LEADER)
-			old_lead.comm_title = "SqSgt"
+			old_lead.comm_title = "SqLdr"
 		if(JOB_SQUAD_SMARTGUN)
 			old_lead.comm_title = "SG"
 		if(JOB_SQUAD_LEADER)

--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -15,7 +15,7 @@
 	lead_name = "Section Sergeant"
 	lead_icon = "leader"
 	sub_squad = "Squad"
-	sub_leader = "Squad Sergeant"
+	sub_leader = "Squad NCO"
 
 /datum/squad_type/marsoc_team
 	name = "Team"
@@ -802,10 +802,10 @@
 			id.access += squad_two_access
 
 	for(var/obj/item/device/radio/headset/cycled_headset in H)
-		if(!("Squad Sergeant" in cycled_headset.tracking_options))
+		if(!("Squad Leader" in cycled_headset.tracking_options))
 			continue
 
-		cycled_headset.locate_setting = cycled_headset.tracking_options["Squad Sergeant"]
+		cycled_headset.locate_setting = cycled_headset.tracking_options["Squad Leader"]
 
 /datum/squad/proc/unassign_fireteam(mob/living/carbon/human/H, upd_ui = TRUE)
 	fireteams[H.assigned_fireteam].Remove(H)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -23,7 +23,7 @@
 	var/list/inbuilt_tracking_options = list(
 		"Platoon Commander" = TRACKER_PLTCO,
 		"Section Sergeant" = TRACKER_SL,
-		"Squad Sergeant" = TRACKER_FTL,
+		"Squad Leader" = TRACKER_FTL,
 		"Landing Zone" = TRACKER_LZ
 	)
 	var/list/tracking_options = list()
@@ -420,8 +420,8 @@
 		locate_setting = tracking_options["Section Sergeant"]
 		return
 
-	if(((user in user.assigned_squad?.fireteams["SQ1"]) || (user in user.assigned_squad?.fireteams["SQ2"])) && ("Squad Sergeant" in tracking_options))
-		locate_setting = tracking_options["Squad Sergeant"]
+	if(((user in user.assigned_squad?.fireteams["SQ1"]) || (user in user.assigned_squad?.fireteams["SQ2"])) && ("Squad Leader" in tracking_options))
+		locate_setting = tracking_options["Squad Leader"]
 		return
 
 /obj/item/device/radio/headset/almayer/verb/enter_tree()

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -258,7 +258,7 @@
 		list("HM", "hudsquad_med"),
 		list("SG", "hudsquad_gun"),
 		list("Spc", "hudsquad_spec"),
-		list("SqSgt", "hudsquad_tl"),
+		list("SqLdr", "hudsquad_tl"),
 		list("SctSgt", "hudsquad_leader"),
 		list("RTO", "hudsquad_rto"),
 	)

--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -262,16 +262,20 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/uscm/tl
-	name = "USCM Squad Sergeant"
+	name = "USCM Squad Leader"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP)
 	assignment = JOB_SQUAD_TEAM_LEADER
 	rank = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
-	role_comm_title = "SqSgt"
+	role_comm_title = "SqLdr"
 	skills = /datum/skills/tl
 	minimap_icon = "tl"
+
+/datum/equipment_preset/uscm/tl/lesser_rank
+	name = parent_type::name + " (Lesser Rank)"
+	paygrades = list(PAY_SHORT_ME4 = JOB_PLAYTIME_TIER_0)
 
 /datum/equipment_preset/uscm/tl/upp
 	name = "UPP Squad Sergeant"
@@ -285,12 +289,24 @@
 	new_human.undershirt = "Naval Infantry Telnyashka"
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/uppcap/beret/naval, WEAR_HEAD)
 
+/datum/equipment_preset/uscm/tl/upp/lesser_rank
+	name = parent_type::name + " (Lesser Rank)"
+	paygrades = list(PAY_SHORT_UE4 = JOB_PLAYTIME_TIER_0)
+
+/datum/equipment_preset/uscm/tl/upp/lesser_rank/load_gear(mob/living/carbon/human/new_human)
+	new_human.undershirt = "Naval Infantry Telnyashka"
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/uppcap/beret/naval, WEAR_HEAD)
+
 /datum/equipment_preset/uscm/tl/forecon
 	name = "FORECON Assistant Squad Leader"
 	assignment = "Assistant Squad Leader"
 	paygrades = list(PAY_SHORT_ME6 = JOB_PLAYTIME_TIER_0)
 	role_comm_title = "ASL"
 	skills = /datum/skills/tl/recon
+
+/datum/equipment_preset/uscm/tl/forecon/lesser_rank
+	name = parent_type::name + " (Lesser Rank)"
+	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
 
 /*****************************************************************************************************/
 
@@ -479,14 +495,14 @@
 //*****************************************************************************************************/
 
 /datum/equipment_preset/uscm/tl_equipped
-	name = "USCM Squad Sergeant (Equipped)"
+	name = "USCM Squad Leader (Equipped)"
 	flags = EQUIPMENT_PRESET_EXTRA|EQUIPMENT_PRESET_MARINE
 
 	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_TL_PREP)
 	assignment = JOB_SQUAD_TEAM_LEADER
 	rank = JOB_SQUAD_TEAM_LEADER
 	paygrades = list(PAY_SHORT_ME5 = JOB_PLAYTIME_TIER_0)
-	role_comm_title = "SqSgt"
+	role_comm_title = "SqLdr"
 	skills = /datum/skills/tl
 
 	minimap_icon = "tl"

--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -7803,7 +7803,7 @@
 	},
 /obj/structure/closet/secure_closet/marine_personal{
 	pixel_x = -7;
-	job = "Squad Sergeant"
+	job = "Squad Leader"
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/cryo_cells)
@@ -8860,7 +8860,7 @@
 	},
 /obj/structure/closet/secure_closet/marine_personal{
 	pixel_x = 8;
-	job = "Squad Sergeant"
+	job = "Squad Leader"
 	},
 /turf/open/floor/almayer/plate,
 /area/golden_arrow/cryo_cells)

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -247,7 +247,7 @@ const RoleTable = (props) => {
           Section Sergeant
         </Table.Cell>
         <Table.Cell collapsing p="4px">
-          Squad Leads
+          Squad Leaders
         </Table.Cell>
         <Table.Cell collapsing p="4px">
           Specialist
@@ -559,7 +559,7 @@ const SquadMonitor = (props) => {
                     <Button
                       icon="arrow-up"
                       color="green"
-                      tooltip="Promote marine to Squad Leader"
+                      tooltip="Promote marine to Unit Leader"
                       onClick={() => act('replace_lead', { ref: marine.ref })}
                     />
                   </Table.Cell>

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -48,7 +48,7 @@ const HomePanel = (props) => {
     <Section
       fontSize="20px"
       textAlign="center"
-      title="OVERWATCH DISABLED - SELECT SQUAD"
+      title="OVERWATCH DISABLED - SELECT UNIT"
     >
       <Stack justify="center" align="end" fontSize="20px">
         {data.squad_list.map((squad, index) => {
@@ -83,7 +83,7 @@ const SquadPanel = (props) => {
         <MainDashboard />
       </Collapsible>
 
-      <Collapsible title="Squad Roles" fontSize="16px">
+      <Collapsible title="Unit Roles" fontSize="16px">
         <RoleTable />
       </Collapsible>
 
@@ -93,7 +93,7 @@ const SquadPanel = (props) => {
           icon="heartbeat"
           onClick={() => setCategory('monitor')}
         >
-          Squad Monitor
+          Unit Monitor
         </Tabs.Tab>
         {!!data.can_launch_crates && (
           <Tabs.Tab

--- a/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
+++ b/tgui/packages/tgui/interfaces/OverwatchConsole.jsx
@@ -247,7 +247,7 @@ const RoleTable = (props) => {
           Section Sergeant
         </Table.Cell>
         <Table.Cell collapsing p="4px">
-          Squad Sergeants
+          Squad Leads
         </Table.Cell>
         <Table.Cell collapsing p="4px">
           Specialist
@@ -323,7 +323,7 @@ const SquadMonitor = (props) => {
     b = b.role;
     const roleValues = {
       'Section Sergeant': 10,
-      'Squad Sergeant': 9,
+      'Squad Leader': 9,
       'Weapons Specialist': 8,
       Smartgunner: 7,
       'Platoon Corpsman': 6,

--- a/tgui/packages/tgui/interfaces/SquadInfo.tsx
+++ b/tgui/packages/tgui/interfaces/SquadInfo.tsx
@@ -282,7 +282,7 @@ const SquadObjectives = (props) => {
 
 export const SquadInfo = () => {
   const { config, data } = useBackend<SquadProps>();
-  const fireteams = ['SQ1', 'SQ2', 'SQ3', 'Unassigned'];
+  const fireteams = ['SQ1', 'SQ2', 'Unassigned'];
 
   return (
     <Window theme="usmc" width={680} height={675}>

--- a/tgui/packages/tgui/interfaces/SquadInfo.tsx
+++ b/tgui/packages/tgui/interfaces/SquadInfo.tsx
@@ -54,7 +54,7 @@ const FireTeamLeadLabel = (props: { readonly ftl: SquadMarineEntry }) => {
   return (
     <>
       <Stack.Item>
-        <span>Squad Sergeant:</span>
+        <span>Squad Leader:</span>
       </Stack.Item>
       <Stack.Item>
         <span
@@ -93,7 +93,7 @@ const FireTeamLead = (props: {
         <Stack>
           {isNotAssigned && (
             <Stack.Item>
-              <span>Squad Sergeant: Unassigned</span>
+              <span>Squad Leader: Unassigned</span>
             </Stack.Item>
           )}
           {!isNotAssigned && <FireTeamLeadLabel ftl={assignedFireteamLead} />}

--- a/tgui/packages/tgui/interfaces/SquadInfo.tsx
+++ b/tgui/packages/tgui/interfaces/SquadInfo.tsx
@@ -24,7 +24,7 @@ interface SquadMarineEntry {
 interface FireTeamEntry {
   name: string;
   total: number;
-  sqsgt?: SquadMarineEntry | [];
+  sqldr?: SquadMarineEntry | [];
   mar: SquadMarineEntry[];
 }
 
@@ -75,10 +75,10 @@ const FireTeamLeadLabel = (props: { readonly ftl: SquadMarineEntry }) => {
 
 const FireTeamLead = (props: {
   readonly fireteam: FireTeamEntry;
-  readonly sqsgt: string;
+  readonly sqldr: string;
 }) => {
   const { data, act } = useBackend<SquadProps>();
-  const fireteamLead = props.fireteam.sqsgt;
+  const fireteamLead = props.fireteam.sqldr;
   const isNotAssigned =
     fireteamLead === undefined ||
     fireteamLead instanceof Array ||
@@ -86,7 +86,7 @@ const FireTeamLead = (props: {
 
   const assignedFireteamLead = fireteamLead as SquadMarineEntry;
 
-  const demote = () => act('demote_ftl', { target_ft: props.sqsgt });
+  const demote = () => act('demote_ftl', { target_ft: props.sqldr });
   return (
     <Flex fill={1} justify="space-between" className="TeamLeadFlex">
       <Flex.Item>
@@ -121,9 +121,9 @@ const FireteamBox = (props: FireteamBoxProps) => {
   );
 };
 
-const FireTeam = (props: { readonly sqsgt: string }) => {
+const FireTeam = (props: { readonly sqldr: string }) => {
   const { data, act } = useBackend<SquadProps>();
-  const fireteam: FireTeamEntry = data.fireteams[props.sqsgt];
+  const fireteam: FireTeamEntry = data.fireteams[props.sqldr];
 
   const members: SquadMarineEntry[] =
     fireteam === undefined
@@ -132,11 +132,11 @@ const FireTeam = (props: { readonly sqsgt: string }) => {
 
   const isEmpty =
     members.length === 0 &&
-    (fireteam?.sqsgt instanceof Array ||
-      fireteam?.sqsgt?.name === 'Not assigned' ||
-      fireteam?.sqsgt?.name === 'Unassigned' ||
-      fireteam?.sqsgt?.name === undefined);
-  const rankList = ['Mar', 'ass', 'Med', 'Eng', 'SG', 'Spc', 'SqSgt', 'PltSgt'];
+    (fireteam?.sqldr instanceof Array ||
+      fireteam?.sqldr?.name === 'Not assigned' ||
+      fireteam?.sqldr?.name === 'Unassigned' ||
+      fireteam?.sqldr?.name === undefined);
+  const rankList = ['Mar', 'ass', 'Med', 'Eng', 'SG', 'Spc', 'SqLdr', 'PltSgt'];
   const rankSort = (a: SquadMarineEntry, b: SquadMarineEntry) => {
     if (a.rank === 'Mar' && b.rank === 'Mar') {
       return a.paygrade === 'PFC' ? -1 : 1;
@@ -155,9 +155,9 @@ const FireTeam = (props: { readonly sqsgt: string }) => {
       <Flex direction="column">
         {!isEmpty && (
           <>
-            {props.sqsgt !== 'Unassigned' && (
+            {props.sqldr !== 'Unassigned' && (
               <Flex.Item>
-                <FireTeamLead fireteam={fireteam} sqsgt={props.sqsgt} />
+                <FireTeamLead fireteam={fireteam} sqldr={props.sqldr} />
               </Flex.Item>
             )}
             <Flex.Item>
@@ -168,7 +168,7 @@ const FireTeam = (props: { readonly sqsgt: string }) => {
                   <TableCell className="MemberCell">Member</TableCell>
                   {data.is_lead === 'sctsgt' && (
                     <TableCell className="ActionCell">
-                      {props.sqsgt === 'Unassigned' ? 'Assign FT' : 'Actions'}
+                      {props.sqldr === 'Unassigned' ? 'Assign FT' : 'Actions'}
                     </TableCell>
                   )}
                 </TableRow>
@@ -177,7 +177,7 @@ const FireTeam = (props: { readonly sqsgt: string }) => {
                     <FireTeamMember
                       member={x}
                       key={x.name}
-                      team={props.sqsgt}
+                      team={props.sqldr}
                       fireteam={fireteam}
                     />
                   </TableRow>
@@ -201,7 +201,7 @@ const FireTeamMember = (props: {
   const assignFT2 = { target_ft: 'SQ2', target_marine: props.member.name };
 
   const promote = () => {
-    const teamlead = props.fireteam?.sqsgt;
+    const teamlead = props.fireteam?.sqldr;
     if (teamlead !== undefined && !(teamlead instanceof Array)) {
       if (teamlead.name !== 'Not assigned') {
         act('demote_ftl', {
@@ -282,7 +282,7 @@ const SquadObjectives = (props) => {
 
 export const SquadInfo = () => {
   const { config, data } = useBackend<SquadProps>();
-  const fireteams = ['SQ1', 'SQ2', 'Unassigned'];
+  const fireteams = ['SQ1', 'SQ2', 'SQ3', 'Unassigned'];
 
   return (
     <Window theme="usmc" width={680} height={675}>
@@ -301,7 +301,7 @@ export const SquadInfo = () => {
             <Section title="Squads">
               <Box className="ftlFlex">
                 {fireteams.map((x) => (
-                  <FireTeam sqsgt={x} key={x} />
+                  <FireTeam sqldr={x} key={x} />
                 ))}
               </Box>
             </Section>


### PR DESCRIPTION
# About the pull request

Adds an alt-rank option of Corporal to the Squad Leader role, which is renamed from Squad Sergeant to reflect the possibility of them being an E4 now. 
The default-picked ranks for new players joining have been swapped out to the lower rank options, this won't affect players who have already saved their role selection at the higher rank options.
A caveat is added to smartgunners and corpsmens round-start info blurb, detailing that even if they are the same rank as a squad leader, the SL has precedence for command over non-SL's of same rank. This is to stop gung-ho SG's trying to usurp the SL's position amidst a squad, or other unlikely situations.

# Explain why it's good for the game

![aliens-shotgun](https://github.com/user-attachments/assets/89819d01-c33d-4101-9d59-4c296924ae92)
Lets people Hicks-max, primarily. The default lower-ranks for new folks also helps them stand out as such rather than everyone being the highest-rank possible for their role.

# Testing Photographs and Procedure
Compiled without issue, tested extensively on local and all worked as intended. (I even got the role lockers to work in the first PR, no follow-up PR's for that needed)

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/5011b6f4-76f9-4970-b58d-07d886eba462)

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Corporal rank variant to the squad leader role
del: Squad sergeant as a USCM role title is gone in favour of the generalised Squad Leader instead. UPP retain it as their E4 equiv reads as 'Junior sergeant' or something to that effect
qol: New players will automatically be set to the lower rank option on jobs until they change it. Existing players should be unaffected by this
ui: References to Squad Sergeant in the UIs replaced with Squad Leader instead
code: Code for the above stuff added/edited as needed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
