### PR TITLE
Returns smoke grenades to the base Garrow build

### DIFF
--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -15521,6 +15521,14 @@
 	},
 /turf/open/floor/almayer/dark_sterile,
 /area/golden_arrow/medical)
+"cMX" = (
+/obj/structure/surface/table/reinforced/black,
+/obj/item/storage/box/nade_box/smoke{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/golden_arrow/supply)
 "cQH" = (
 /obj/structure/machinery/door/poddoor/almayer{
 	name = "\improper Lower Storage Bay Five Blast Door";
@@ -15996,6 +16004,9 @@
 /area/golden_arrow/engineering)
 "exo" = (
 /obj/structure/surface/table/reinforced/black,
+/obj/item/storage/box/nade_box/smoke{
+	pixel_y = -7
+	},
 /turf/open/floor/plating/plating_catwalk,
 /area/golden_arrow/supply)
 "eyg" = (
@@ -33070,7 +33081,7 @@ aLe
 ati
 roZ
 odS
-exo
+cMX
 rdX
 btA
 rTJ


### PR DESCRIPTION
# About the pull request

Adds two boxes of M47 HSDP smoke grenades to the Garrow cargo bay. Shrimple as

# Explain why it's good for the game

We've been lacking map-standard smoke grenades on the Garrow for a while now. With the frequency of hAI ops as of late, they're basically mandatory for those kinds of ops, this just eases the need for GM's to spawn in some.

# Changelog

:cl:
maptweak: Garrow cargo bay now has a pair of smoke grenade boxes
/:cl:

