### PR TITLE
Blood restoring Chems no longer depend on a Threshold of Nutrition

### DIFF
--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -108,8 +108,6 @@
 /datum/chem_property/positive/hemogenic/process(mob/living/M, potency = 1, delta_time)
 	if(!iscarbon(M))
 		return
-	if(M.nutrition < 200)
-		return
 
 	handle_nutrition_loss(M, potency, delta_time)
 	M.blood_volume = min(M.blood_volume + potency, M.limit_blood)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# Explain why it's good for the game

This is not really conveyed in-game, especially to the medic who is treating the patient.
Food still gives all the benefits it has, and nutrition is still drained by PROPERTY_HEMOGENIC, but it no longer prevents Iron, Water etc from working below a nutrition threshold.


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Blood restoring medicine no longer depends on a minimum threshold of nutrition.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
