### PR TITLE
Ports a few more QoL PR's from PVP

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -187,28 +187,39 @@
 		QDEL_NULL(H.stamina)
 		H.stamina = new stamina_type(H)
 
-/datum/species/proc/hug(mob/living/carbon/human/H, mob/living/carbon/target, target_zone = "chest")
-	if(H.flags_emote)
+/datum/species/proc/hug(mob/living/carbon/human/human, mob/living/carbon/target, target_zone = "chest")
+	if(human.flags_emote)
 		return
 	var/t_him = target.p_them()
 
+	//answer the call
+	if(target.flags_emote & EMOTING_HIGH_FIVE)
+		attempt_high_five(human, target)
+		return
+	else if(target.flags_emote & EMOTING_FIST_BUMP)
+		attempt_fist_bump(human, target)
+		return
+	else if(target.flags_emote & EMOTING_ROCK_PAPER_SCISSORS)
+		attempt_rock_paper_scissors(human, target)
+		return
+
 	if(target_zone == "head")
-		attempt_rock_paper_scissors(H, target)
+		attempt_rock_paper_scissors(human, target)
 		return
 	else if(target_zone in list("l_arm", "r_arm"))
-		attempt_high_five(H, target)
+		attempt_high_five(human, target)
 		return
 	else if(target_zone in list("l_hand", "r_hand"))
-		attempt_fist_bump(H, target)
+		attempt_fist_bump(human, target)
 		return
-	else if(H.body_position == LYING_DOWN) // Keep other interactions above lying check for maximum awkwardness potential
-		H.visible_message(SPAN_NOTICE("[H] waves at [target] to make [t_him] feel better!"), \
+	else if(human.body_position == LYING_DOWN) // Keep other interactions above lying check for maximum awkwardness potential
+		human.visible_message(SPAN_NOTICE("[human] waves at [target] to make [t_him] feel better!"), \
 			SPAN_NOTICE("You wave at [target] to make [t_him] feel better!"), null, 4)
 	else if(target_zone == "groin")
-		H.visible_message(SPAN_NOTICE("[H] hugs [target] to make [t_him] feel better!"), \
+		human.visible_message(SPAN_NOTICE("[human] hugs [target] to make [t_him] feel better!"), \
 			SPAN_NOTICE("You hug [target] to make [t_him] feel better!"), null, 4)
 	else
-		H.visible_message(SPAN_NOTICE("[H] pats [target] on the back to make [t_him] feel better!"), \
+		human.visible_message(SPAN_NOTICE("[human] pats [target] on the back to make [t_him] feel better!"), \
 			SPAN_NOTICE("You pat [target] on the back to make [t_him] feel better!"), null, 4)
 	playsound(target, 'sound/weapons/thudswoosh.ogg', 25, 1, 5)
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -171,8 +171,8 @@ window "mainwindow"
 		menu = "menu"
 	elem "split"
 		type = CHILD
-		pos = 3,0
-		size = 634x440
+		pos = 0,0
+		size = 640x440
 		anchor1 = 0,0
 		anchor2 = 100,100
 		saved-params = "splitter"


### PR DESCRIPTION
# About the pull request

Ports [#8282](https://github.com/cmss13-devs/cmss13/pull/8282) and [#8353](https://github.com/cmss13-devs/cmss13/pull/8353) from PVP
Credits to the respective PR authors for the codechanges
Copies of their PR entries are below;

1. Only need to click them on help intent to answer now.
2. Fixes accidental border dragging by removing the side padding.

# Explain why it's good for the game

1. A bit annoying and confusing that you need to target a specific limb to answer high-five. People fail at this all the time. While definitely a skill issue, there is not much reason to keep it this annoying.
2. Prevents accidentally dragging the border and resizing the client window. See video for an example.
Literal ided issue as I've killed myself several times by doing this when trying to dash out of CAS etc.

# Testing Photographs and Procedure
Compiles without issue, tested locally and functioned as expected

# Changelog

:cl:
qol: answering an emote such as high-five no longer requires targeting a specific limb.
qol: Removed client window side padding to prevent accidental dragging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
