### PR TITLE
Removes radios from the autolathe [TM ONLY]

### DIFF
--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -72,16 +72,6 @@
 	path = /obj/item/tool/mop
 	category = AUTOLATHE_CATEGORY_TOOLS
 
-/datum/autolathe/recipe/radio_headset
-	name = "radio headset"
-	path = /obj/item/device/radio/headset
-	category = AUTOLATHE_CATEGORY_GENERAL
-
-/datum/autolathe/recipe/radio_bounced
-	name = "shortwave radio"
-	path = /obj/item/device/radio/off
-	category = AUTOLATHE_CATEGORY_GENERAL
-
 /datum/autolathe/recipe/weldermask
 	name = "welding mask"
 	path = /obj/item/clothing/head/welding


### PR DESCRIPTION
# About the pull request

See title

# Explain why it's good for the game

Requested by a dork for their isolation round(s)

# Testing Photographs and Procedure
🍋

# Changelog

:cl:
del: Station-bounced radio & radio headset removed from autolathe list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
