### PR TITLE
Reverses #739

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -40,9 +40,6 @@
 ///Delete the timer on parent datum Destroy() and when deltimer'd
 #define TIMER_DELETE_ME (1<<6)
 
-//Makes the timer perform its callback as it is being destroyed.
-#define TIMER_COMPLETE_ON_DELETE (1<<7)
-
 ///Empty ID define
 #define TIMER_ID_NULL -1
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -427,9 +427,6 @@ SUBSYSTEM_DEF(timer)
 /datum/timedevent/Destroy()
 	..()
 
-	if (flags & TIMER_COMPLETE_ON_DELETE)
-		call(callBack.object, callBack.delegate)(arglist(callBack.arguments))
-
 	if (flags & TIMER_UNIQUE && hash)
 		timer_subsystem.hashes -= hash
 

--- a/code/datums/langchat/langchat.dm
+++ b/code/datums/langchat/langchat.dm
@@ -138,7 +138,7 @@
 			langchat_image.alpha = 0
 			animate(langchat_image, pixel_y = langchat_image.pixel_y + LANGCHAT_MESSAGE_FAST_POP_Y_SINK, alpha = LANGCHAT_MAX_ALPHA, time = LANGCHAT_MESSAGE_FAST_POP_TIME)
 
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, langchat_drop_image), language), timer, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT|TIMER_COMPLETE_ON_DELETE)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, langchat_drop_image), language), timer, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_NO_HASH_WAIT)
 
 /atom/proc/langchat_long_speech(message, list/listeners, language)
 	langchat_drop_image()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# Explain why it's good for the game
Reverses #739, which prevented langchat emotes from overlapping each other on everything, Makes overhead chat less functional and causes more harm than it prevented.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Reverses a fix to force narrate that made langchat unable to overlap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
