### PR TITLE
Use github app for ci

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -13,12 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
+    - name: Generate App Token
+      id: app-token-generation
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        token: ${{ steps.app-token-generation.outputs.token }}
+
     - name: Run auto changelog
       uses: actions/github-script@v6
       with:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
           await processAutoChangelog({ github, context })
-        github-token: ${{ secrets.BOT_TOKEN_CM || secrets.GITHUB_TOKEN }}
+        github-token: ${{ steps.app-token-generation.outputs.token }}

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -18,6 +18,14 @@ jobs:
           unset SECRET_EXISTS
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
           echo "ACTIONS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
+
+      - name: Generate App Token
+        id: app-token-generation
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: "Setup python"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: actions/setup-python@v3
@@ -35,6 +43,7 @@ jobs:
         with:
           fetch-depth: 25
           persist-credentials: false
+          token: ${{ steps.app-token-generation.outputs.token }}
       - name: "Compile"
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
@@ -42,8 +51,8 @@ jobs:
       - name: Commit
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "Changelogs"
+          git config --local user.email "${{ secrets.APP_PUBLIC_ID }}+${{ secrets.APP_PUBLIC_NAME }}[bot]@users.noreply.github.com"
+          git config --local user.name "${{ secrets.APP_PUBLIC_NAME }}[bot]"
           git pull origin master
           git add html/changelogs/archive
           git commit -m "Automatic changelog compile [ci skip]" -a || true
@@ -51,4 +60,4 @@ jobs:
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.BOT_TOKEN_CM || secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token-generation.outputs.token }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -35,5 +35,5 @@ jobs:
           python add_labels.py
         env:
           REPO: ${{ github.repository }}
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ steps.app-token-generation.outputs.token }}
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,6 +14,14 @@ jobs:
           unset SECRET_EXISTS
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
           echo "ACTIONS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
+
+      - name: Generate App Token
+        id: app-token-generation
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Get The Script
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |

--- a/.github/workflows/run_approval.yml
+++ b/.github/workflows/run_approval.yml
@@ -7,9 +7,16 @@ jobs:
     name: Automatic Approve Workflows
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token-generation
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Automatic Approve
         uses: mheap/automatic-approve-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token-generation.outputs.token }}
           workflows: "ci_suite.yml"
           dangerous_files: "build.bat"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,9 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    - name: Generate App Token
+      id: app-token-generation
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - uses: actions/stale@v4
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ steps.app-token-generation.outputs.token }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 14 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
         days-before-stale: 14
         days-before-close: 14

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -9,6 +9,14 @@ jobs:
     concurrency: changelog
     runs-on: ubuntu-latest
     steps:
+
+    - name: Generate App Token
+      id: app-token-generation
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
       id: value_holder
       env:
@@ -31,6 +39,8 @@ jobs:
     - name: Checkout
       if: steps.value_holder.outputs.ACTIONS_ENABLED
       uses: actions/checkout@v3
+      with:
+        token: ${{ steps.app-token-generation.outputs.token }}
     - name: Fetch Changelog
       if: steps.value_holder.outputs.ACTIONS_ENABLED
       run: |
@@ -45,12 +55,12 @@ jobs:
       if: steps.value_holder.outputs.ACTIONS_ENABLED
       run: |
         git pull origin master
-        git config --local user.email "action@github.com"
-        git config --local user.name "Changelogs"
+        git config --local user.email "${{ secrets.APP_PUBLIC_ID }}+${{ secrets.APP_PUBLIC_NAME }}[bot]@users.noreply.github.com"
+        git config --local user.name "${{ secrets.APP_PUBLIC_NAME }}[bot]"
         git add html/changelogs/archive
         git commit -m "Automatic changelog compile [ci skip]" -a || true
     - name: "Push"
       if: steps.value_holder.outputs.ACTIONS_ENABLED
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ steps.app-token-generation.outputs.token }}

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -10,8 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Update the TGS DMAPI
     steps:
+
+    - name: Generate App Token
+      id: app-token-generation
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - name: Clone
       uses: actions/checkout@v3
+      with:
+        token: ${{ steps.app-token-generation.outputs.token }}
 
     - name: Branch
       run: |
@@ -28,8 +38,8 @@ jobs:
     - name: Commit and Push
       continue-on-error: true
       run: |
-        git config user.name tgstation-server
-        git config user.email tgstation-server@users.noreply.github.com
+        git config user.name "${{ secrets.APP_PUBLIC_NAME }}[bot]"
+        git config user.email "${{ secrets.APP_PUBLIC_ID }}+${{ secrets.APP_PUBLIC_NAME }}[bot]@users.noreply.github.com"
         git add .
         git commit -m 'Update TGS DMAPI'
         git push -f -u origin tgs-dmapi-update
@@ -44,4 +54,4 @@ jobs:
         pr_body: "This pull request updates the TGS DMAPI to the latest version. Please note any breaking or unimplemented changes before merging."
         pr_label: "Tools"
         pr_allow_empty: false
-        github_token: ${{ secrets.BOT_TOKEN_CM }}
+        github_token: ${{ steps.app-token-generation.outputs.token }}

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -60,7 +60,7 @@ def main(repo : pygit2.Repository):
 
     # Set up upstream remote if needed
     try:
-        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13.git")
+        repo.remotes.create("upstream", "https://github.com/cmss13-devs/cmss13-pve.git")
     except ValueError:
         pass
     else:


### PR DESCRIPTION

# About the pull request

This PR is a follow up to #797 incorporating different handling for github secrets in CI, and a correction to fixup.py using pvp's url instead of pve's.

# Explain why it's good for the game

More Harry magic.

# Testing Photographs and Procedure
See checks.

# Changelog

No player facing changes.
