### PR TITLE
Examine shows if human will be shot by IFF+nIFF lets you shoot when stacked on someone.

### DIFF
--- a/code/datums/components/iff_fire_prevention.dm
+++ b/code/datums/components/iff_fire_prevention.dm
@@ -76,6 +76,8 @@
 		for(var/mob/living/checked_living in checked_turf)
 			if(checked_living == user) // sometimes it still happens
 				continue
+			if(checked_living.loc == user.loc) //behave like everyother gun, the bullets physically can't hit them anyway
+				continue
 			if(checked_living.body_position == LYING_DOWN && projectile_to_fire.original != checked_living)
 				continue
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -160,6 +160,33 @@
 	if(wear_id)
 		msg += "[t_He] [t_is] [wear_id.get_examine_location(src, user, WEAR_ID, t_He, t_his, t_him, t_has, t_is)].\n"
 
+	//Inform user if their weapon's IFF will or won't hit src
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_with_gun = user
+		if(istype(user.r_hand, /obj/item/weapon/gun) || istype(user.l_hand, /obj/item/weapon/gun))
+			var/obj/item/weapon/gun/gun_with_iff
+			var/found_iff = FALSE
+			if(istype(user.r_hand, /obj/item/weapon/gun))
+				gun_with_iff = user.r_hand
+			else if(istype(user.l_hand, /obj/item/weapon/gun))
+				gun_with_iff = user.l_hand
+			if(gun_with_iff)
+				for(var/obj/item/attachable/attachment in gun_with_iff.contents)
+					if(locate(/datum/element/bullet_trait_iff) in attachment.traits_to_give)
+						found_iff = TRUE
+						break
+				if(gun_with_iff.traits_to_give != null)
+					if(gun_with_iff.traits_to_give.Find("iff"))
+						found_iff = TRUE
+				if(gun_with_iff.in_chamber != null && gun_with_iff.in_chamber.bullet_traits != null )
+					if(gun_with_iff.in_chamber.bullet_traits.Find("iff"))
+						found_iff = TRUE
+				if(found_iff)
+					if(get_target_lock(human_with_gun.get_id_faction_group()) > 0)
+						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapons IFF.\n")
+					else
+						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapons IFF. They will be shot by your weapon!\n")
+
 	//Restraints
 	if(handcuffed)
 		msg += SPAN_ORANGE("[capitalize(t_his)] arms are restrained by [handcuffed].\n")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -163,13 +163,10 @@
 	//Inform user if their weapon's IFF will or won't hit src
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_with_gun = user
-		if(istype(user.r_hand, /obj/item/weapon/gun) || istype(user.l_hand, /obj/item/weapon/gun))
+		if(istype(human_with_gun.r_hand, /obj/item/weapon/gun) || istype(human_with_gun.l_hand, /obj/item/weapon/gun))
 			var/obj/item/weapon/gun/gun_with_iff
 			var/found_iff = FALSE
-			if(istype(user.r_hand, /obj/item/weapon/gun))
-				gun_with_iff = user.r_hand
-			else if(istype(user.l_hand, /obj/item/weapon/gun))
-				gun_with_iff = user.l_hand
+			gun_with_iff = human_with_gun.get_active_hand()
 			if(gun_with_iff)
 				for(var/obj/item/attachable/attachment in gun_with_iff.contents)
 					if(locate(/datum/element/bullet_trait_iff) in attachment.traits_to_give)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -182,7 +182,7 @@
 					if(get_target_lock(human_with_gun.get_id_faction_group()) > 0)
 						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapons IFF.\n")
 					else
-						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapons IFF. They will be shot by your weapon!\n")
+						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapon's IFF. They will be shot by your weapon!\n")
 
 	//Restraints
 	if(handcuffed)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -180,7 +180,7 @@
 						found_iff = TRUE
 				if(found_iff)
 					if(get_target_lock(human_with_gun.get_id_faction_group()) > 0)
-						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapons IFF.\n")
+						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapon's IFF.\n")
 					else
 						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapon's IFF. They will be shot by your weapon!\n")
 


### PR DESCRIPTION

# About the pull request

Examine now shows if the IFF enabled weapon in your character's hand will shoot the human.
An IFF enabled human does not stop your character shooting their nIFF weapon while on their loc.

# Explain why it's good for the game

QoL.
This is how every other gun in the game works as of right now.

# Changelog
:cl:
add: Examining a human will show if they will be shot by the currently held weapon.
fix: SG can now fire while another IFF enabled human is directly on it's place.
/:cl:
