### PR TITLE
HUDs moved to the helmet visors (by & large)

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -456,9 +456,21 @@
 /atom/movable/screen/squad_leader_locator/clicked(mob/living/carbon/human/user, mods)
 	if(!istype(user))
 		return
+
+	///The object which we're using the tracking options from.
+	var/obj/item/device/tracker_object
+
 	var/obj/item/device/radio/headset/earpiece = user.get_type_in_ears(/obj/item/device/radio/headset)
-	var/has_access = earpiece.misc_tracking || (user.assigned_squad && user.assigned_squad.radio_freq == earpiece.frequency)
-	if(!istype(earpiece) || !earpiece.has_hud || !has_access)
+	var/has_access = earpiece?.misc_tracking || (user.assigned_squad && user.assigned_squad.radio_freq == earpiece?.frequency)
+	if(istype(earpiece) && earpiece.has_hud && has_access)
+		tracker_object = earpiece
+
+	//visor is the 2nd pick
+	var/obj/item/device/helmet_visor/visor = locate() in user.head
+	if(visor?.has_tracker && !tracker_object)
+		tracker_object = visor
+
+	if(!tracker_object)
 		to_chat(user, SPAN_WARNING("Unauthorized access detected."))
 		return
 	if(mods["shift"])
@@ -466,7 +478,7 @@
 		to_chat(user, SPAN_NOTICE("You are currently at: <b>[current_area.name]</b>."))
 		return
 	else if(mods["alt"])
-		earpiece.switch_tracker_target()
+		tracker_object.switch_tracker_target()
 		return
 	if(user.get_active_hand())
 		return

--- a/code/controllers/subsystem/tracking.dm
+++ b/code/controllers/subsystem/tracking.dm
@@ -44,10 +44,15 @@ SUBSYSTEM_DEF(tracking)
 			if(ishuman(current_mob))
 				var/mob/living/carbon/human/human_mob = current_mob
 				var/obj/item/device/radio/headset/almayer/marine/earpiece = human_mob.get_type_in_ears(/obj/item/device/radio/headset)
-				if(earpiece?.has_hud)
+				var/has_access = earpiece?.misc_tracking || (human_mob.assigned_squad && human_mob.assigned_squad.radio_freq == earpiece?.frequency)
+				if(earpiece?.has_hud && has_access)
 					human_mob.locate_squad_leader(earpiece.locate_setting)
 				else
-					human_mob.locate_squad_leader()
+					var/obj/item/device/helmet_visor/visor = locate() in human_mob.head
+					if(visor?.has_tracker)
+						human_mob.locate_squad_leader(visor.locate_setting)
+					else
+						human_mob.locate_squad_leader()
 			else if(isxeno(current_mob))
 				var/mob/living/carbon/xenomorph/xeno_mob = current_mob
 				xeno_mob.queen_locator()

--- a/code/game/objects/items/devices/helmet_visors.dm
+++ b/code/game/objects/items/devices/helmet_visors.dm
@@ -20,6 +20,20 @@
 	///The overlay name for when our visor is active, in 'icons/mob/humans/onmob/helmet_garb.dmi'
 	var/helmet_overlay = "hud_sight_right"
 
+	///Whether the visor allows tracking squad members or not.
+	var/has_tracker = TRUE
+
+	///Default tracking options for the visor.
+	var/list/tracking_options = list(
+		"Platoon Commander" = TRACKER_PLTCO,
+		"Platoon Sergeant" = TRACKER_SL,
+		"Squad Sergeant" = TRACKER_FTL,
+		"Landing Zone" = TRACKER_LZ
+		)
+
+	///The target that we are currently tracking.
+	var/locate_setting = TRACKER_SL
+
 /obj/item/device/helmet_visor/Destroy(force)
 	if(!istype(loc, /obj/item/clothing/head/helmet/marine))
 		return ..()
@@ -64,10 +78,21 @@
 	var/datum/mob_hud/current_mob_hud = GLOB.huds[hud_type]
 	current_mob_hud.add_hud_to(user, attached_helmet)
 
+	if(has_tracker && user.mind && user.assigned_squad && user.hud_used && user.hud_used.locate_leader)
+		user.show_hud_tracker()
+
 /// Called by toggle_visor() to deactivate the visor's effects
 /obj/item/device/helmet_visor/proc/deactivate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
 	var/datum/mob_hud/current_mob_hud = GLOB.huds[hud_type]
 	current_mob_hud.remove_hud_from(user, attached_helmet)
+
+	if(has_tracker && user.hud_used && user.hud_used.locate_leader)
+		//if we have a headset that also lets us track targets, do not hide the HUD.
+		var/obj/item/device/radio/headset/earpiece = user.get_type_in_ears(/obj/item/device/radio/headset)
+		var/has_access = earpiece?.misc_tracking || (user.assigned_squad && user.assigned_squad.radio_freq == earpiece?.frequency)
+		if(istype(earpiece) && earpiece.has_hud && has_access)
+			return
+		user.hide_hud_tracker()
 
 /// Called by /obj/item/clothing/head/helmet/marine/get_examine_text(mob/user) to get extra examine text for this visor
 /obj/item/device/helmet_visor/proc/get_helmet_examine_text()
@@ -87,7 +112,23 @@
 
 /obj/item/device/helmet_visor/medical/advanced
 	name = "advanced medical optic"
-	helmet_overlay = "med_sight_right"
+	helmet_overlay = "med_sight_left"
+	hud_type = list(MOB_HUD_FACTION_MARINE, MOB_HUD_MEDICAL_ADVANCED)
+
+/obj/item/device/helmet_visor/medical/advanced/activate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
+	. = ..()
+	for(var/type in hud_type)
+		var/datum/mob_hud/current_mob_hud = GLOB.huds[type]
+		current_mob_hud.add_hud_to(user, attached_helmet)
+
+/obj/item/device/helmet_visor/medical/advanced/deactivate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
+	. = ..()
+	for(var/type in hud_type)
+		var/datum/mob_hud/current_mob_hud = GLOB.huds[type]
+		current_mob_hud.remove_hud_from(user, attached_helmet)
+
+/obj/item/device/helmet_visor/medical/advanced/process(delta_time)
+	return PROCESS_KILL
 
 /obj/item/device/helmet_visor/medical/advanced/can_toggle(mob/living/carbon/human/user)
 	. = ..()
@@ -160,6 +201,7 @@
 	hud_type = null
 	action_icon_string = "blank_hud_sight_down"
 	helmet_overlay = "weld_visor"
+	has_tracker = FALSE
 
 /obj/item/device/helmet_visor/welding_visor/activate_visor(obj/item/clothing/head/helmet/marine/attached_helmet, mob/living/carbon/human/user)
 	attached_helmet.vision_impair = VISION_IMPAIR_MAX

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -58,7 +58,7 @@
 	if(has_hud)
 		headset_hud_on = TRUE
 		verbs += /obj/item/device/radio/headset/proc/toggle_squadhud
-		verbs += /obj/item/device/radio/headset/proc/switch_tracker_target
+		verbs += /obj/item/device/proc/switch_tracker_target
 
 	if(frequency)
 		for(var/cycled_channel in GLOB.radiochannels)
@@ -256,9 +256,13 @@
 		if(headset_hud_on)
 			var/datum/mob_hud/H = GLOB.huds[hud_type]
 			H.add_hud_to(user, src)
-			//squad leader locator is no longer invisible on our player HUD.
-			if(user.mind && (user.assigned_squad || misc_tracking) && user.hud_used && user.hud_used.locate_leader)
-				user.show_hud_tracker()
+		var/obj/item/clothing/head/helmet/marine/worn_helmet = user.head
+		if(!istype(worn_helmet))
+			// If their hat isn't a marine helmet, we won't take it into account for the next check
+			worn_helmet = null
+		//squad leader locator is invisible again unless a visor tracker is active
+		if(!worn_helmet?.active_visor?.has_tracker && user.hud_used && user.hud_used.locate_leader)
+			user.show_hud_tracker()
 			if(misc_tracking)
 				SStracking.start_misc_tracking(user)
 			INVOKE_NEXT_TICK(src, PROC_REF(update_minimap_icon), wearer)
@@ -323,7 +327,7 @@
 	to_chat(usr, SPAN_NOTICE("You toggle [src]'s headset HUD [headset_hud_on ? "on":"off"]."))
 	playsound(src,'sound/machines/click.ogg', 20, 1)
 
-/obj/item/device/radio/headset/proc/switch_tracker_target()
+/obj/item/device/proc/switch_tracker_target()
 	set name = "Switch Tracker Target"
 	set category = "Object"
 	set src in usr
@@ -333,12 +337,16 @@
 
 	handle_switching_tracker_target(usr)
 
-/obj/item/device/radio/headset/proc/handle_switching_tracker_target(mob/living/carbon/human/user)
-	var/new_track = tgui_input_list(user, "Choose a new tracking target.", "Tracking Selection", tracking_options)
+/obj/item/device/proc/handle_switching_tracker_target(mob/living/carbon/human/user)
+	if(!is_type_in_list(src, list(/obj/item/device/radio/headset, /obj/item/device/helmet_visor)))
+		return
+
+	var/obj/item/device/radio/headset/tracker_item = src
+	var/new_track = tgui_input_list(user, "Choose a new tracking target.", "Tracking Selection", tracker_item.tracking_options)
 	if(!new_track)
 		return
-	to_chat(user, SPAN_NOTICE("You set your headset's tracker to point to <b>[new_track]</b>."))
-	locate_setting = tracking_options[new_track]
+	to_chat(user, SPAN_NOTICE("You set your tracker to point to <b>[new_track]</b>."))
+	tracker_item.locate_setting = tracker_item.tracking_options[new_track]
 
 /obj/item/device/radio/headset/proc/update_minimap_icon()
 	SIGNAL_HANDLER
@@ -411,7 +419,7 @@
 	icon_state = "generic_headset"
 	item_state = "headset"
 	frequency = PUB_FREQ
-	has_hud = TRUE
+	has_hud = FALSE
 
 /obj/item/device/radio/headset/almayer/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
@@ -621,11 +629,13 @@
 	initial_keys = list(/obj/item/device/encryptionkey/cmpcom/synth)
 	volume = RADIO_VOLUME_CRITICAL
 	misc_tracking = TRUE
+	has_hud = TRUE	// Synth retains as they don't often wear helmets
 	locate_setting = TRACKER_ASL
 
 	inbuilt_tracking_options = list(
 		"Platoon Commander" = TRACKER_PLTCO,
-		"Section Sergeant" = TRACKER_ASL,
+		"A-Section Sergeant" = TRACKER_ASL,
+		"B-Section Sergeant" = TRACKER_BSL,
 		"Landing Zone" = TRACKER_LZ
 	)
 
@@ -672,7 +682,6 @@
 	icon_state = "upp_headset"
 	item_state = "upp_headset"
 	frequency = UPP_FREQ
-	has_hud = TRUE
 	hud_type = MOB_HUD_FACTION_UPP
 	minimap_type = MINIMAP_FLAG_UPP
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -815,8 +815,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	desc = "M10 combat helmet issued to marine hospital corpsmen. Has a red cross painted on its front for attracting the injured and snipers' attentions alike."
 	icon_state = "med_helmet"
 	specialty = "M10 pattern medic"
-	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/medical/advanced)
-	start_down_visor_type = /obj/item/device/helmet_visor/medical/advanced
+	built_in_visors = list(new /obj/item/device/helmet_visor/medical/advanced)
 
 /obj/item/clothing/head/helmet/marine/medic/white
 	name = "\improper M10 white corpsman helmet"


### PR DESCRIPTION
# About the pull request

Finishes the work done by Amory & Vile in #424 to move the squad HUD functionality into the helmet visor instead of being tied to the headset, along with giving the bucket tracker functionality too. The headset retains the tracker too as a fallback option. FORECON & USCM synthetic headsets for the moment keep the HUD tied to it, as they don't normally get helmets.
The corpsman helmet comes with a combi squad & advanced medical hud now, so they won't need to toggle between them constantly to check who's who in the section/platoon & who's hurting

# Explain why it's good for the game

No more magi-HUD on an earpiece, I know Amory mentioned making a special eyepiece/version for FORECON in the future so their headsets no longer need the HUD tied into it too.
Encourages taking a helmet for the optic on it now.

# Testing Photographs and Procedure
Compiled without issue, tested locally & works as intended. Didn't run into any bugs during the testing.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: The M10's squad optic visor now functions as the primary means of seeing who is who amongst the section/platoon at a glance. The squad management menu is still accessible with just the headset and the tracker will point to your squad lead/section lead
add: The M42A, M42C, UPP commando NVGs and M56 gunsight optic now offer corresponding faction HUDs, for those who run those kinds of eyepieces without a helmet
del: Removes the HUD functionality on the base USCM & UPP headsets, FORECON & synthetics retain it for the time being
qol: The corpsman helmet now toggles both the squad hud & advanced medical hud at the same time, rather than needing to cycle through them
code: Adaptable code for future HUD & tracker-providing items such as hudglasses or similar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
