### PR TITLE
Fixes CustomItems entries requiring exact ckey matches

### DIFF
--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 		// split & clean up
 		var/list/Entry = splittext(line, ":")
 		for(var/i = 1 to length(Entry))
-			Entry[i] = trim(Entry[i])
+			Entry[i] = ckey(Entry[i])
 
 		if(length(Entry) < 2)
 			continue;

--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -11,7 +11,10 @@ GLOBAL_LIST_FILE_LOAD(custom_items, "config/custom_items.txt")
 		// split & clean up
 		var/list/Entry = splittext(line, ":")
 		for(var/i = 1 to length(Entry))
-			Entry[i] = ckey(Entry[i])
+			if(i == 1)
+				Entry[i] = ckey(Entry[i])
+			else
+				Entry[i] = trim(Entry[i])
 
 		if(length(Entry) < 2)
 			continue;


### PR DESCRIPTION
# About the pull request

This PR simply makes the custom_items.txt config more flexible by passing the key into the [ckey proc](https://www.byond.com/docs/ref/#/proc/ckey).

# Explain why it's good for the game

Less confusion for Verbs.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/f8c3b59f-03b7-43d1-a3dd-f36d5cefd794)

</details>


# Changelog
:cl: Drathek
fix: Custom items config now passes key entries into the ckey proc to be properly stripped
/:cl:
