### PR TITLE
upp and pmc sg harnesses name bug fixed

### DIFF
--- a/code/modules/clothing/suits/marine_armor/smartgunner.dm
+++ b/code/modules/clothing/suits/marine_armor/smartgunner.dm
@@ -31,8 +31,6 @@
 	. = ..()
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD] && name == "\improper M56 combat harness" && !(flags_atom & NO_SNOW_TYPE))
 		name = "M56 snow combat harness"
-	else
-		name = "M56 combat harness"
 	//select_gamemode_skin(type)
 
 /obj/item/clothing/suit/storage/marine/smartgunner/mob_can_equip(mob/equipping_mob, slot, disable_warning = FALSE)
@@ -111,8 +109,6 @@
 	. = ..()
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD] && name == "\improper M56 combat harness" && !(flags_atom & NO_SNOW_TYPE))
 		name = "\improper M56 snow combat harness"
-	else
-		name = "\improper M56 combat harness"
 	//select_gamemode_skin(type)
 
 /obj/item/clothing/suit/marine/smartgunner/mob_can_equip(mob/equipping_mob, slot, disable_warning = FALSE)


### PR DESCRIPTION

# About the pull request

yeeep
# Explain why it's good for the game
yeeeep

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: UPP machinegunner armor and PMC weapons specialist armor are now named correctly.
/:cl:
