### PR TITLE
Halves untrained pointing cooldown 

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -379,7 +379,7 @@
 		recently_pointed_to = world.time + 10
 		new /obj/effect/overlay/temp/point/big(T, src, A)
 	else
-		recently_pointed_to = world.time + 50
+		recently_pointed_to = world.time + 2.5 SECONDS
 		new /obj/effect/overlay/temp/point(T, src, A)
 	visible_message("<b>[src]</b> points to [A]", null, null, 5)
 	return TRUE


### PR DESCRIPTION
# About the pull request

Port of [https://github.com/cmss13-devs/cmss13/pull/8626](url)
Suggested by Slayer

Simply halves the pointing cooldown from 50 ticks to 25 ticks for untrained.
Leadership trained pointing stays at 10 ticks. 

# Explain why it's good for the game
Removes the awkward pause when frantically trying to point to something rushing at you. 

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Halves untrained pointing cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
