### PR TITLE
Fix Examining Breaking when holding a Gun and another Item

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -160,18 +160,17 @@
 	if(wear_id)
 		msg += "[t_He] [t_is] [wear_id.get_examine_location(src, user, WEAR_ID, t_He, t_his, t_him, t_has, t_is)].\n"
 
-	//Inform user if their weapon's IFF will or won't hit src
+		//Inform user if their weapon's IFF will or won't hit src, code by The32bitguy from PVE
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_with_gun = user
-		if(istype(human_with_gun.r_hand, /obj/item/weapon/gun) || istype(human_with_gun.l_hand, /obj/item/weapon/gun))
+		if(istype(human_with_gun.r_hand, human_with_gun.get_active_hand()))
 			var/obj/item/weapon/gun/gun_with_iff
 			var/found_iff = FALSE
 			gun_with_iff = human_with_gun.get_active_hand()
-			if(gun_with_iff)
-				for(var/obj/item/attachable/attachment in gun_with_iff.contents)
-					if(locate(/datum/element/bullet_trait_iff) in attachment.traits_to_give)
-						found_iff = TRUE
-						break
+			for(var/obj/item/attachable/attachment in gun_with_iff.contents)
+				if(locate(/datum/element/bullet_trait_iff) in attachment.traits_to_give)
+					found_iff = TRUE
+			if(gun_with_iff.GetComponent(/datum/component/iff_fire_prevention) || found_iff)
 				if(gun_with_iff.traits_to_give != null)
 					if(gun_with_iff.traits_to_give.Find("iff"))
 						found_iff = TRUE
@@ -183,7 +182,6 @@
 						msg += SPAN_HELPFUL("[capitalize(t_He)] is compatible with your weapon's IFF.\n")
 					else
 						msg += SPAN_DANGER("[capitalize(t_He)] is not compatible with your weapon's IFF. They will be shot by your weapon!\n")
-
 	//Restraints
 	if(handcuffed)
 		msg += SPAN_ORANGE("[capitalize(t_his)] arms are restrained by [handcuffed].\n")


### PR DESCRIPTION
# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Examining humans is now possible while holding a gun and another item(bug)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
