### PR TITLE
Fix Portrait Announcements being Cut Off and Changes the Sound

### DIFF
--- a/code/modules/maptext_alerts/command_alert.dm
+++ b/code/modules/maptext_alerts/command_alert.dm
@@ -46,7 +46,7 @@
 	log_game("[key_name(human_owner)] has broadcasted the hud message [text] at [AREACOORD(human_owner)]")
 	var/override_color
 	var/list/alert_receivers = list()
-	var/sound_alert
+	var/sound_alert = 'sound/effects/radiostatic.ogg'
 	var/announcement_title
 
 	if(human_owner.assigned_squad)
@@ -72,12 +72,10 @@
 				override_color = "green"
 			else
 				override_color = "grey"
-		sound_alert = 'sound/misc/notice2.ogg'
 	else
 		for(var/mob/living/carbon/human/alerted in GLOB.alive_human_list)
 			if(alerted.faction == human_owner.faction)
 				alert_receivers += alerted
-		sound_alert = 'sound/effects/sos-morse-code.ogg'
 		announcement_title = "[human_owner.job]'s Announcement"
 	alert_receivers += GLOB.observer_list
 	if(GLOB.radio_communication_clarity < 100)

--- a/code/modules/maptext_alerts/misc_alert.dm
+++ b/code/modules/maptext_alerts/misc_alert.dm
@@ -47,7 +47,7 @@
 /atom/movable/screen/text/screen_text/potrait
 	screen_loc = "LEFT,TOP-3"
 	maptext_height = 64
-	maptext_width = 480
+	maptext_width = 400
 	maptext_x = 66
 	maptext_y = 0
 	letters_per_update = 2
@@ -85,6 +85,7 @@
 /atom/movable/screen/text/screen_text/picture/potrait_custom_mugshot
 	image_to_play = "custom"
 	screen_loc = "LEFT,TOP-3"
+	maptext_width = 400
 	image_to_play_offset_y = 0
 	maptext_y = 0
 	letters_per_update = 2


### PR DESCRIPTION

# About the pull request
was cut off if too long due to maptext width being too high and changes the sound to be the radiostatic sound
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
fix
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/f0c4fd11-9d05-4232-b96c-3027b0c641e8)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: Fix Portrait Announcements being Cut Off
/:cl:
