### PR TITLE
Vehicle names fix

### DIFF
--- a/code/modules/vehicles/van/ambulance.dm
+++ b/code/modules/vehicles/van/ambulance.dm
@@ -4,7 +4,7 @@
 //Read the documentation in multitile.dm before trying to decipher this stuff
 
 /obj/vehicle/multitile/box_van/ambulance
-	name = "\improper box-van"
+	name = "\improper ambulance"
 	desc = "An ambulance. It's used to transport critically injured patients."
 	icon = 'icons/obj/vehicles/ambulance.dmi'
 

--- a/code/modules/vehicles/van/cop_car.dm
+++ b/code/modules/vehicles/van/cop_car.dm
@@ -4,7 +4,7 @@
 //Read the documentation in multitile.dm before trying to decipher this stuff
 
 /obj/vehicle/multitile/box_van/cop_car
-	name = "\improper box-van"
+	name = "\improper Mono-Spectra"
 	desc = "A police car. Used to transport law enforcement and criminals alike."
 	icon = 'icons/obj/vehicles/cop_car.dmi'
 


### PR DESCRIPTION

# About the pull request
Fixes an oversight where the ambulance and cop car are mistakenly named as 'box vans'.

# Explain why it's good for the game
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
fix: ambulance and cop car names fixed
/:cl:
