### PR TITLE
More PvP UI Fix Ports & Misc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,9 @@
 	},
 	"workbench.editorAssociations": {
 		"*.dmi": "dmiEditor.dmiEditor"
-	}
+	},
+	"tgstationTestExplorer.project.DMEName": "colonialmarines.dme",
+	"dreammaker.tickOnCreate": true,
+	"dreammaker.reparseOnSave": true,
+	"dreammaker.autoUpdate": true
 }

--- a/code/__DEFINES/_click.dm
+++ b/code/__DEFINES/_click.dm
@@ -10,6 +10,9 @@
 ///if(modifiers[BUTTON] == LEFT_CLICK)
 #define BUTTON "button"
 
+#define BUTTON4 "xbutton1"
+#define BUTTON5 "xbutton2"
+
 //Keys held down during the mouse action
 #define CTRL_CLICK "ctrl"
 #define ALT_CLICK "alt"
@@ -35,3 +38,8 @@
 
 //Pixel coordinates in screen_loc format ("[tile_x]:[pixel_x],[tile_y]:[pixel_y]")
 #define SCREEN_LOC "screen-loc"
+
+/// From /mob/proc/click_adjacent() : (atom/A, obj/item/W, mods) makes it so the affterattack proc isn't called
+#define ATTACKBY_HINT_NO_AFTERATTACK (1 << 0)
+/// From /mob/proc/click_adjacent() : (atom/A, obj/item/W, mods) applies the click delay to next_move
+#define ATTACKBY_HINT_UPDATE_NEXT_MOVE (1 << 1)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -82,8 +82,10 @@
 		return
 
 	face_atom(A)
-	if(mods["middle"])
+
+	if(mods[MIDDLE_CLICK] || mods[BUTTON4] || mods[BUTTON5])
 		return
+
 	// Special type of click.
 	if (is_mob_restrained())
 		RestrainedClickOn(A)

--- a/tgui/packages/tgui-panel/audio/player.ts
+++ b/tgui/packages/tgui-panel/audio/player.ts
@@ -67,7 +67,7 @@ export class AudioPlayer {
       });
     }
 
-    audio.play();
+    audio.play().catch((error) => logger.log('playback error', error));
 
     this.onPlaySubscribers.forEach((subscriber) => subscriber());
   }

--- a/tgui/packages/tgui-panel/chat/renderer.tsx
+++ b/tgui/packages/tgui-panel/chat/renderer.tsx
@@ -144,6 +144,7 @@ class ChatRenderer {
         highlightWholeMessage: boolean;
       }[]
     | null;
+  lastScrollHeight: number;
   constructor() {
     /** @type {HTMLElement} */
     this.loaded = false;
@@ -159,13 +160,15 @@ class ChatRenderer {
     /** @type {HTMLElement} */
     this.scrollNode = null;
     this.scrollTracking = true;
+    this.lastScrollHeight = 0;
     this.handleScroll = (type) => {
       const node = this.scrollNode;
       if (node) {
         const height = node.scrollHeight;
         const bottom = node.scrollTop + node.offsetHeight;
         const scrollTracking =
-          Math.abs(height - bottom) < SCROLL_TRACKING_TOLERANCE;
+          Math.abs(height - bottom) < SCROLL_TRACKING_TOLERANCE ||
+          this.lastScrollHeight === 0;
         if (scrollTracking !== this.scrollTracking) {
           this.scrollTracking = scrollTracking;
           this.events.emit('scrollTrackingChanged', scrollTracking);
@@ -392,6 +395,10 @@ class ChatRenderer {
         this.queue = [...this.queue, ...batch];
       }
       return;
+    }
+    // Store last scroll position
+    if (this.scrollNode) {
+      this.lastScrollHeight = this.scrollNode.scrollHeight;
     }
     // Insert messages
     const fragment = document.createDocumentFragment();

--- a/tgui/packages/tgui/interfaces/MfdPanels/FiremissionPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MfdPanels/FiremissionPanel.tsx
@@ -374,7 +374,7 @@ const OffsetDetailed = (
     readonly equipment: DropshipEquipment;
   },
 ) => {
-  const availableGimbals = gimbals[props.equipment.mount_point];
+  const availableGimbals = gimbals[props.equipment.mount_point] ?? gimbals[0];
   const weaponFm = props.fm.records.find(
     (x) => x.weapon === props.equipment.mount_point,
   );
@@ -455,7 +455,7 @@ const FMOffsetStack = (
   )?.offsets;
 
   const { editFm } = fmEditState(props.panelStateId);
-  const availableGimbals = gimbals[props.equipment.mount_point];
+  const availableGimbals = gimbals[props.equipment.mount_point] ?? gimbals[0];
 
   const firemissionOffsets = props.equipment.firemission_delay ?? 0;
 

--- a/tgui/packages/tgui/interfaces/PingRelaysPanel.tsx
+++ b/tgui/packages/tgui/interfaces/PingRelaysPanel.tsx
@@ -147,7 +147,8 @@ class PingApp extends Component<PingAppProps> {
                       value={result.ping}
                       maxValue={1000}
                       minValue={50}
-                      minWidth={4}
+                      minWidth={3.8}
+                      pr={1}
                       ranges={{
                         good: [0, 200],
                         average: [200, 500],


### PR DESCRIPTION
# About the pull request

This PR ports the following PRs:
- https://github.com/cmss13-devs/cmss13/pull/8874
- https://github.com/cmss13-devs/cmss13/pull/8875
- https://github.com/cmss13-devs/cmss13/pull/8870
- https://github.com/cmss13-devs/cmss13/pull/8915
- https://github.com/cmss13-devs/cmss13/pull/8916
- https://github.com/cmss13-devs/cmss13/pull/8896

The mouse 4/5 & audio player fixes likely need to be explored more in the future.

# Changelog
:cl: Harry Drathek Kashargul
fix: mouse 4/5 presses no longer count as mouse 1 presses
fix: the audio player shouldn't blow up in weird circumstances
fix: Dropship equipment weapons that aren't in a weapon slot now get defaulted gimbal offsets (none) instead of crashing
ui: Tweaked the size of gauges in the ping relay browser
fix: large batch processes offsetting the chat scrollbar
/:cl:
