### PR TITLE
 fix: fix concurrent map reading of same map files

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -207,6 +207,7 @@
 	var/stored_index = 1
 	var/list/regexOutput
 	//multiz lool
+	dmm_regex.next = stored_index // CM addition: Neccessary to reset start position in case of loading the same file concurrently. Putting it in Find() below is NOT enough!
 	while(dmm_regex.Find(tfile, stored_index))
 		stored_index = dmm_regex.next
 		// Datum var lookup is expensive, this isn't


### PR DESCRIPTION
# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Should fix #682 

# Changelog
:cl:
fix: Fixed improper concurrent reading on map files, notably for Vans on Otogi.
/:cl:
