### PR TITLE
Removes "statis" from the hypersleep pod description

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(frozen_items, list(SQUAD_MARINE_1 = list(), SQUAD_MARINE_2 = li
 //Cryopods themselves.
 /obj/structure/machinery/cryopod
 	name = "hypersleep chamber"
-	desc = "A large automated capsule with LED displays intended to put anyone inside into 'hypersleep', a form of non-cryogenic statis used on most ships."
+	desc = "A large automated capsule with LED displays intended to put anyone inside into 'hypersleep', a form of non-cryogenic stasis used on most ships."
 	icon = 'icons/obj/structures/machinery/cryogenics.dmi'
 	icon_state = "hypersleep_open"
 	density = TRUE


### PR DESCRIPTION
# About the pull request
Typo.
# Explain why it's good for the game
Typo bad.
# Changelog

:cl:
spellcheck: Fixes a one letter typo in the hypersleep pod description
/:cl:
