### PR TITLE
Adds USCM Headset to FORECON vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -715,6 +715,7 @@
 		list("Boonie Hat (olive)", round(scale * 5), /obj/item/clothing/head/cmcap/boonie, VENDOR_ITEM_REGULAR),
 		list("Boonie Hat (tan)", round(scale * 5), /obj/item/clothing/head/cmcap/boonie/tan, VENDOR_ITEM_REGULAR),
 		list("Cap", round(scale * 5), /obj/item/clothing/head/cmcap, VENDOR_ITEM_REGULAR),
+		list("USCM Headset", round(scale * 5), /obj/item/clothing/head/headset, VENDOR_ITEM_REGULAR),
 		list("Headband (brown)", round(scale * 5), /obj/item/clothing/head/headband/brown, VENDOR_ITEM_REGULAR),
 		list("Headband (gray)", round(scale * 5), /obj/item/clothing/head/headband/brown, VENDOR_ITEM_REGULAR),
 		list("Headband (red)", round(scale * 5), /obj/item/clothing/head/headband/red, VENDOR_ITEM_REGULAR),

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -182,7 +182,7 @@
 
 /obj/item/clothing/head/headset
 	name = "\improper USCM headset"
-	desc = "A large headset used in conjunction with the standard headset. Large enough that it doesn't fit with any other headwear. Typically found in use by radio-operators and officers."
+	desc = "A large headset used in conjunction with the standard one. Large enough that it doesn't fit with any other headwear. Typically found in use by radio-operators and officers."
 	icon_state = "headset"
 	icon = 'icons/obj/items/clothing/cm_hats.dmi'
 	item_icons = list(

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -182,7 +182,7 @@
 
 /obj/item/clothing/head/headset
 	name = "\improper USCM headset"
-	desc = "A headset typically found in use by radio-operators and officers. This one appears to be malfunctioning."
+	desc = "A large headset used in conjunction with the standard headset. Large enough that it doesn't fit with any other headwear. Typically found in use by radio-operators and officers."
 	icon_state = "headset"
 	icon = 'icons/obj/items/clothing/cm_hats.dmi'
 	item_icons = list(


### PR DESCRIPTION

# About the pull request

Adds a USCM Headset to the FORECON vendor. Adjusted the description of the USCM headset.

# Explain why it's good for the game

It's an option for those who wants a minimalist headgear as FORECON. Also, you can now bowmanmaxx.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: lordloko
add: Added USCM Headset to FORECON vendor. Adjusted the description.
/:cl:
