### PR TITLE
Tweaks some of the more egregious non-combat stuns

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(airlock_wire_descriptions, list(
 		else if(user.hallucination > 50 && prob(10) && operating == 0)
 			to_chat(user, SPAN_DANGER("<B>You feel a powerful shock course through your body!</B>"))
 			user.halloss += 10
-			user.apply_effect(10, STUN)
+			user.apply_effect(3, STUN)
 			return
 	..(user)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -200,8 +200,8 @@
 			apply_effect(1, STUN)//Sadly, something has to stop them from bumping them 10 times in a second
 			apply_effect(1, WEAKEN)
 		else
-			apply_effect(6, STUN)//This should work for now, more is really silly and makes you lay there forever
-			apply_effect(6, WEAKEN)
+			apply_effect(3, STUN)//This should work for now, more is really silly and makes you lay there forever
+			apply_effect(3, WEAKEN)
 
 		count_niche_stat(STATISTICS_NICHE_SHOCK)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -861,7 +861,7 @@
 		addtimer(CALLBACK(src, PROC_REF(do_vomit)), 25 SECONDS)
 
 /mob/living/carbon/human/proc/do_vomit()
-	apply_effect(5, STUN)
+	apply_effect(2, STUN)
 	if(stat == 2) //One last corpse check
 		return
 	src.visible_message(SPAN_WARNING("[src] throws up!"), SPAN_WARNING("You throw up!"), null, 5)


### PR DESCRIPTION
# About the pull request

Adjusts the duration of the stun applied when throwing up & from messing with a shocked door whilst lacking PPE

# Explain why it's good for the game

Lingering balance decisions from PvP code-folks getting taken out back and shot in the interests of a more enjoyable game experience for the players is always a good thing imo

# Changelog

:cl:
qol: Vomit & door-shock stuns are lessened considerably
balance: As above, technically a balance thing too
/:cl:
