### PR TITLE
No more baseball-god hAI antics

### DIFF
--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_items.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_items.dm
@@ -425,7 +425,9 @@
 
 			if(thing.flags_human_ai & GRENADE_ITEM)
 				var/obj/item/explosive/grenade/nade = thing
-				if(nade.active)
+				if(nade.active && (nade.fuse_type == IMPACT_FUSE))
+					return
+				else if(nade.active && (nade.fuse_type == TIMED_FUSE))
 					active_grenade_found = thing
 					continue
 


### PR DESCRIPTION
# About the pull request

Makes it so hAI aren't going to pick up mid-flight impact-detonating grenades fired by UGLs anymore. They will still pick up timer-fused grenades fired by them however. _That_ is a bit more reasonable.

# Explain why it's good for the game

HAI being able to pick up grenades that are ostensibly primed to detonate on impact only to hurl them back at you as a player was _immensely_ frustrating and rather un-fun. This remedies that.

# Testing Photographs and Procedure
Compiled without issue, tested on local and works as intended

# Changelog

:cl:
qol: hAI will no longer throw grenades made to be impact-fused by a UGL back at players
balance: As above, is a balance change too
/:cl:
