### PR TITLE
M5 RPG AT-Viability upped

### DIFF
--- a/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/rocket_launcher.dm
@@ -40,6 +40,11 @@
 /obj/item/weapon/gun/launcher/rocket/set_gun_attachment_offsets()
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 19, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 
+/obj/item/weapon/gun/launcher/rocket/set_bullet_traits()
+	. = ..()
+	LAZYADD(traits_to_give, list(
+		BULLET_TRAIT_ENTRY_ID("vehicles", /datum/element/bullet_trait_damage_boost, 70, GLOB.damage_boost_vehicles),
+	))
 
 /obj/item/weapon/gun/launcher/rocket/set_gun_config_values()
 	..()


### PR DESCRIPTION
# About the pull request

Ups the damage the M5 will do vs vehicles so it isn't woefully inadequate in the anti-tank role despite having anti-armor rounds

# Explain why it's good for the game

With factions besides the UA having vehicles now, a greater selection of AT weapons that are viable is a good thing. The M5 anti-armor round will bust tires & seriously damage the other modules of non-tank vehicles, so the SADAR retains a niche for the "kill it NOW" effect

# Testing Photographs and Procedure
Compiled without issue, tested on local, works as expected

# Changelog

:cl:
qol: The M5 anti-armor rounds will now actually damage vehicles hit by them
balance: As above, also a balance change
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
