### PR TITLE
Gives LTs their clothes back after Amory stole them

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -263,7 +263,7 @@
 			var/datum/job/J = GLOB.RoleAuthority.roles_by_name[JOB_CO]
 			return J.gear_preset_whitelist["[JOB_CO][J.get_whitelist_status(owner)]"]
 		if(JOB_SO)
-			return /datum/equipment_preset/uscm_ship/so
+			return /datum/equipment_preset/uscm_ship/so_equipped
 		if(JOB_XO)
 			return /datum/equipment_preset/uscm_ship/xo
 		/*


### PR DESCRIPTION
# About the pull request
Changes /datum/equipment_preset/uscm_ship/so to /datum/equipment_preset/uscm_ship/so_equipped so PlatCOs actually get to have clothes while previewing their character/observing.
# Explain why it's good for the game
No more naked PlatCO ghosts.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/5b5f7c51-2b2e-439a-979c-85d6c14ea475)

</details>

# Changelog
:cl:
fix: Platoon Commanders now use the proper equipped preset in the setup menu.
/:cl:
