### PR TITLE
Mirror: Fix: Auto verbing for '!' and '? '

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -4,6 +4,7 @@
 #define LANGUAGE_RUSSIAN "Russian"
 #define LANGUAGE_RUSPATOIS "Russian Patois"
 #define LANGUAGE_GERMAN "German"
+#define LANGUAGE_SCANDINAVIAN "Scandinavian"
 #define LANGUAGE_SPANISH "Spanish"
 #define LANGUAGE_PORTUGUESE "Portuguese"
 #define LANGUAGE_FRENCH "French"

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -246,7 +246,10 @@
 		/* --- Process all the mobs that heard the voice normally (did not understand) --- */
 		if (length(heard_voice))
 			for (var/mob/R in heard_voice)
-				R.hear_radio(message,verbage, speaking, part_a, part_b, M,0, vname, 0)
+				if(R.faction == M.faction)
+					R.hear_radio(message, verbage, speaking, part_a, part_b, M, 0, realname, volume)
+				else
+					R.hear_radio(message, verbage, speaking, part_a, part_b, M, 0, vname, 0)
 
 		/* --- Process all the mobs that heard a garbled voice (did not understand) --- */
 			// Displays garbled message (ie "f*c* **u, **i*er!")

--- a/code/modules/character_traits/languages.dm
+++ b/code/modules/character_traits/languages.dm
@@ -35,6 +35,11 @@
 	applyable = TRUE
 	cost = 1
 
+/datum/character_trait/language/scandinavian
+	language_name = LANGUAGE_SCANDINAVIAN
+	applyable = TRUE
+	cost = 1
+
 /datum/character_trait/language/german
 	language_name = LANGUAGE_GERMAN
 	applyable = TRUE

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -35,20 +35,13 @@
 			understood = 1
 
 		if(understood)
-			if(!speaker_mask) speaker_mask = speaker.name
+			if(!speaker_mask)
+				speaker_mask = speaker.name
 			var/msg = "<i><span class='game say'>[name], <span class='name'>[speaker_mask]</span> <span class='message'>[speech_verb], \"<span class='[color]'>[message]</span><span class='message'>\"</span></span></span></i>"
 			to_chat(player, "[msg]")
 
 /datum/language/proc/check_special_condition(mob/other)
 	return 1
-
-/datum/language/proc/get_spoken_verb(msg_end)
-	switch(msg_end)
-		if("!")
-			return exclaim_verb
-		if("?")
-			return ask_verb
-	return speech_verb
 
 /datum/language/proc/check_cache(input)
 	var/lookup = scramble_cache[input]

--- a/code/modules/mob/language/languages.dm
+++ b/code/modules/mob/language/languages.dm
@@ -200,7 +200,7 @@
 	speech_verb = "states"
 	ask_verb = "queries"
 	exclaim_verb = "declares"
-	key = "6"
+	key = "a"
 	flags = RESTRICTED|HIVEMIND
 
 /datum/language/apollo/broadcast(mob/living/speaker, message, speaker_mask)
@@ -251,5 +251,5 @@
 	ask_verb = "resonates"
 	exclaim_verb = "resonates"
 	color = "tajaran"
-	key = "8"
+	key = "t"
 	flags = RESTRICTED|HIVEMIND

--- a/code/modules/mob/language/languages.dm
+++ b/code/modules/mob/language/languages.dm
@@ -2,20 +2,12 @@
 	name = LANGUAGE_ENGLISH
 	desc = "Common Earth English. The standard language of the United Americas."
 	speech_verb = "says"
+	ask_verb = "asks"
+	exclaim_verb = list("exclaims","shouts","yells")
 	key = "1"
 	flags = RESTRICTED
 
 	syllables = list("al", "an", "ar", "as", "at", "ea", "ed", "en", "er", "es", "ha", "he", "hi", "in", "is", "it", "le", "me", "nd", "ne", "ng", "nt", "on", "or", "ou", "re", "se", "st", "te", "th", "ti", "to", "ve", "wa", "all", "and", "are", "but", "ent", "era", "ere", "eve", "for", "had", "hat", "hen", "her", "hin", "his", "ing", "ion", "ith", "not", "ome", "oul", "our", "sho", "ted", "ter", "tha", "the", "thi", "tio", "uld", "ver", "was", "wit", "you")
-
-/datum/language/common/get_spoken_verb(msg_end)
-	switch(msg_end)
-		if("!")
-			return pick("exclaims","shouts","yells") //TODO: make the basic proc handle lists of verbs.
-		if("?")
-			return ask_verb
-	return speech_verb
-
-
 /datum/language/generated //parent type for languages with custom sound generation methods like chinese and japanese
 	space_chance = 100 //uses a unique system
 
@@ -31,9 +23,9 @@
 /datum/language/generated/chinese
 	name = LANGUAGE_CHINESE
 	desc = "The secondary language of the UPP, widespread around Asia and with a notable immigrant population in other parts of the world. The most spoken language in charted space."
-	speech_verb = "shuo"
-	ask_verb = "wen"
-	exclaim_verb = "han"
+	speech_verb = "voices"
+	ask_verb = "questions"
+	exclaim_verb = "shouts"
 	color = "chinese"
 	key = "8"
 
@@ -66,12 +58,24 @@
 
 	syllables = list("die", "das", "wein", "mir", "und", "wir", "ein", "nein", "gen", "en", "sauen", "bin", "nein", "rhein", "deut", "der", "lieb", "en", "stein", "nein", "ja", "wolle", "sil", "bei", "der", "sie", "sch", "kein", "nur", "ach", "kann", "volk", "vau", "gelb", "grun", "macht", "zwei", "vier", "nacht", "tag")
 
+/datum/language/scandinavian
+	name = LANGUAGE_SCANDINAVIAN
+	desc = "While not technically one language, Scandinavian languages have grown similar and are nearly indistinguishable from one another unless you actually know the languages."
+	speech_verb = "utters"
+	ask_verb = "queries"
+	exclaim_verb = "yelps"
+	color = "scandinavian"
+	key = "0"
+
+	syllables = list("de", "vin", "meg", "og", "vi", "en", "nei", "ing", "gen", "et", "pur", "ke", "er", "nei", "hjort", "tysk", "de", "kjae", "en", "stein", "ja", "ull", "sil", "pa", "hun", "kjo", "erg", "ba", "re", "ol", "kyll", "menn", "esk", "gul", "gronn", "natt", "makt", "to", "fi", "re", "dag", "god", "jul", "ild", "fem", "jeg", "deg", "bjor", "en", "russ", "land", "sve", "rig", "nor", "ge", "dan", "is")
+
+
 /datum/language/spanish
 	name = LANGUAGE_SPANISH
 	desc = "The second most common language spoken in the UA, brought from marines from the Latin American territories and in the former southern USA."
-	speech_verb = "dice"
-	ask_verb = "cuestiona"
-	exclaim_verb = "grita"
+	speech_verb = "states"
+	ask_verb = "quizes"
+	exclaim_verb = "yells"
 	color = "spanish"
 	key = "5"
 
@@ -80,9 +84,9 @@
 /datum/language/portuguese
 	name = LANGUAGE_PORTUGUESE
 	desc = "The third most common language spoken in the UA."
-	speech_verb = "dice"
-	ask_verb = "pregunta"
-	exclaim_verb = "grita"
+	speech_verb = "states"
+	ask_verb = "quizes"
+	exclaim_verb = "yells"
 	color = "portuguese"
 	key = "6"
 
@@ -102,9 +106,9 @@
 /datum/language/filipino
 	name = LANGUAGE_FILIPINO
 	desc = "The fourth most common language spoken in the UA."
-	speech_verb = "dice"
-	ask_verb = "cuestiona"
-	exclaim_verb = "grita"
+	speech_verb = "states"
+	ask_verb = "quizes"
+	exclaim_verb = "yells"
 	color = "filipino"
 	key = "f"
 
@@ -156,7 +160,7 @@
 	ask_verb = "chimpers"
 	exclaim_verb = "screeches"
 	color = "monkey"
-	key = null
+	key = "_"
 
 /datum/language/xenomorph
 	name = LANGUAGE_XENOMORPH
@@ -166,6 +170,7 @@
 	ask_verb = "hisses"
 	exclaim_verb = "hisses"
 	key = "x"
+	syllables = list("sss", "sSs", "SSS")
 	flags = RESTRICTED
 
 /datum/language/xenos

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -102,11 +102,11 @@
 	if (speaking)
 		var/ending = copytext(message, length(message))
 		if(ending=="!")
-			verb = speaking.exclaim_verb
+			verb = pick(speaking.exclaim_verb)
 		else if(ending=="?")
-			verb = speaking.ask_verb
+			verb = pick(speaking.ask_verb)
 		else
-			verb = speaking.speech_verb
+			verb = pick(speaking.speech_verb)
 		// This is broadcast to all mobs with the language,
 		// irrespective of distance or anything else.
 		if(speaking.flags & HIVEMIND)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -71,6 +71,9 @@
 
 	message = trim(strip_html(message))
 
+	if(!filter_message(src, message))
+		return
+
 	if(stat == DEAD)
 		return say_dead(message)
 
@@ -87,12 +90,23 @@
 		to_chat(src, SPAN_WARNING(fail_message))
 		return
 	message = parsed["message"]
+
+	if(!filter_message(src, message))
+		return
+
 	var/datum/language/speaking = parsed["language"]
 	if(!speaking)
 		speaking = get_default_language()
 
-	var/ending = copytext(message, length(message))
+
 	if (speaking)
+		var/ending = copytext(message, length(message))
+		if(ending=="!")
+			verb = speaking.exclaim_verb
+		else if(ending=="?")
+			verb = speaking.ask_verb
+		else
+			verb = speaking.speech_verb
 		// This is broadcast to all mobs with the language,
 		// irrespective of distance or anything else.
 		if(speaking.flags & HIVEMIND)
@@ -102,20 +116,18 @@
 			speaking.broadcast(src, trim(message))
 			return
 		//If we've gotten this far, keep going!
-		verb = speaking.get_spoken_verb(ending)
 	else
-		if(ending=="!")
-			verb=pick("exclaims","shouts","yells")
-		if(ending=="?")
-			verb="asks"
-
+		verb = "says"
 	if (istype(wear_mask, /obj/item/clothing/mask/muzzle))
+		return
+
+	if (istype(wear_mask, /obj/item/clothing/mask/facehugger))
 		return
 
 	message = capitalize(trim(message))
 	message = process_chat_markup(message, list("~", "_"))
 
-	var/list/handle_r = handle_speech_problems(message)
+	var/list/handle_r = handle_speech_problems(message, verb)
 	message = handle_r[1]
 	verb = handle_r[2]
 	if(!message)
@@ -247,19 +259,15 @@ for it but just ignore it.
 	var/verb = "says"
 	var/ending = copytext(message, length(message))
 
-	if(speaking)
-		verb = speaking.get_spoken_verb(ending)
-	else
-		if(ending == "!")
-			verb=pick("exclaims","shouts","yells")
-		else if(ending == "?")
-			verb="asks"
+	if(ending == "!")
+		verb = pick("exclaims","shouts","yells")
+	if(ending == "?")
+		verb = "asks"
 
 	return verb
 
-/mob/living/carbon/human/proc/handle_speech_problems(message)
+/mob/living/carbon/human/proc/handle_speech_problems(message, verb)
 	var/list/returns[2]
-	var/verb = "says"
 	if(silent)
 		message = ""
 	if(sdisabilities & DISABILITY_MUTE)


### PR DESCRIPTION
# About the pull request
Mirrors: https://github.com/cmss13-devs/cmss13/pull/9179

Add the verb argument to the speech_problems thing.
Uses the verbs found in the languages. Also makes them lists so you can add to them for extra flavour. And allows English to still have it's three choices for exclaiming

This affects **local**, and **radio**.

Changes some language verbs to English ones as it's weird to have them not English, when you can understand at least that they're shouting in your face or trying to ask you a question

Also adds Scandinavian from PvP *shrug


Also allows same faction mobs to know the speaker over the radio if they're speaking a language they don't understand.
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Fix a thing that has been broken for... however long.
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: MistChristmas
fix: Messages ending in '!' and '?' change the verb from 'says' to 'shouts/yells/exclaims' or 'asks' again or their language equivalent.
add: Scandinavian Language is now pickable as an character trait.
/:cl: