### PR TITLE
GM Defence Creator Panel - IFF Factions fix

### DIFF
--- a/code/modules/mob/living/carbon/human/ai/defense_creator.dm
+++ b/code/modules/mob/living/carbon/human/ai/defense_creator.dm
@@ -43,7 +43,7 @@
 	var/list/data = list()
 
 	data["defenses"] = lazy_ui_data
-	data["valid_factions"] = list(FACTION_MARINE, FACTION_UPP, FACTION_WY, FACTION_CLF, FACTION_FREELANCER, FACTION_TWE)
+	data["valid_factions"] = list(FACTION_MARINE, FACTION_UA_REBEL, FACTION_UPP, FACTION_CANC, FACTION_WY, FACTION_FREELANCER, FACTION_TWE, FACTION_TWE_REBEL)
 
 	return data
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

added the new insurgent factions to the IFF lists for the GM Defence Creator panel

# Explain why it's good for the game

now CLF is gone, GMs can add claymores/sentries etc for the new three insurgent factions

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl:
fix: added UA Rebel, TWE Rebel and CANC (aka UPP Rebel) to the IFF faction list for Defense Creator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
