### PR TITLE
Adds a buckable handrail & view port to tanks

### DIFF
--- a/maps/interiors/tank.dmm
+++ b/maps/interiors/tank.dmm
@@ -45,6 +45,20 @@
 	pixel_x = 9;
 	pixel_y = 31
 	},
+/obj/structure/bed/chair/dropship{
+	icon = 'icons/obj/structures/handrail.dmi';
+	icon_state = "handrail_strata";
+	indestructible = 1;
+	name = "handrail seat";
+	dir = 8;
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 4;
+	pixel_y = 15;
+	pixel_x = -5
+	},
 /turf/open/shuttle/vehicle/floor_1_11,
 /area/interior/vehicle/tank)
 "r" = (

--- a/maps/interiors/tank.dmm
+++ b/maps/interiors/tank.dmm
@@ -50,9 +50,9 @@
 	icon_state = "handrail_strata";
 	indestructible = 1;
 	name = "handrail seat";
-	dir = 8;
+	dir = 4;
 	pixel_y = 2;
-	pixel_x = 2
+	pixel_x = -28
 	},
 /obj/effect/landmark/interior/spawn/interior_viewport{
 	dir = 4;

--- a/maps/interiors/tank.dmm
+++ b/maps/interiors/tank.dmm
@@ -48,7 +48,6 @@
 /obj/structure/bed/chair/dropship{
 	icon = 'icons/obj/structures/handrail.dmi';
 	icon_state = "handrail_strata";
-	indestructible = 1;
 	name = "handrail seat";
 	dir = 4;
 	pixel_y = 2;


### PR DESCRIPTION

# About the pull request
At the request of aimless, placed what is essentially a third seat in the tank along with a viewport
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Now it's a three person coffin!
# Testing Photographs and Procedure
![tankhandrail](https://github.com/user-attachments/assets/fa86032b-78d3-4022-871a-a8177f9f0b26)


# Changelog
:cl:
maptweak: edits tank interior to have a buckable rail along with a viewport
/:cl:
