### PR TITLE
hAI factions fixes & tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_factions.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_factions.dm
@@ -97,10 +97,98 @@
 /datum/human_ai_faction/proc/get_shoot_to_kill()
 	return shoot_to_kill
 
+/datum/human_ai_faction/colonist
+	faction = FACTION_COLONIST
+	friendly_factions = list(
+		FACTION_SURVIVOR,
+		FACTION_MARINE,
+		FACTION_ARMY,
+		FACTION_NAVY,
+		FACTION_UPP,
+		FACTION_MARSHAL,
+		FACTION_TWE,
+		FACTION_WY,
+		FACTION_PMC,
+	)
+	neutral_factions = list(
+		FACTION_FREELANCER,
+		FACTION_CONTRACTOR,
+		FACTION_MERCENARY,
+		FACTION_CANC,
+		FACTION_TWE_REBEL,
+		FACTION_UA_REBEL,
+	)
+
+/datum/human_ai_faction/contractor
+	faction = FACTION_CONTRACTOR
+	friendly_factions = list(
+		FACTION_SURVIVOR,
+		FACTION_MARINE,
+		FACTION_ARMY,
+		FACTION_NAVY,
+		FACTION_UPP,
+		FACTION_MARSHAL,
+		FACTION_TWE,
+		FACTION_WY,
+		FACTION_PMC,
+	)
+	neutral_factions = list(
+		FACTION_FREELANCER,
+		FACTION_MERCENARY,
+		FACTION_CANC,
+		FACTION_TWE_REBEL,
+		FACTION_UA_REBEL,
+	)
+
+/datum/human_ai_faction/merc
+	faction = FACTION_MERCENARY
+	friendly_factions = list(
+		FACTION_SURVIVOR,
+		FACTION_MARINE,
+		FACTION_ARMY,
+		FACTION_NAVY,
+		FACTION_UPP,
+		FACTION_MARSHAL,
+		FACTION_TWE,
+		FACTION_WY,
+		FACTION_PMC,
+	)
+	neutral_factions = list(
+		FACTION_FREELANCER,
+		FACTION_CONTRACTOR,
+		FACTION_CANC,
+		FACTION_TWE_REBEL,
+		FACTION_UA_REBEL,
+	)
+
+/datum/human_ai_faction/lancer
+	faction = FACTION_FREELANCER
+	friendly_factions = list(
+		FACTION_SURVIVOR,
+		FACTION_MARINE,
+		FACTION_ARMY,
+		FACTION_NAVY,
+		FACTION_UPP,
+		FACTION_MARSHAL,
+		FACTION_TWE,
+		FACTION_WY,
+		FACTION_PMC,
+	)
+	neutral_factions = list(
+		FACTION_CONTRACTOR,
+		FACTION_MERCENARY,
+		FACTION_CANC,
+		FACTION_TWE_REBEL,
+		FACTION_UA_REBEL,
+	)
+
 /datum/human_ai_faction/twerebel
 	faction = FACTION_TWE_REBEL
 	friendly_factions = list(
 		FACTION_COLONIST,
+	)
+	neutral_factions = list(
+		FACTION_SURVIVOR,
 	)
 	enter_combat_lines = list(
 		"Look alive!",
@@ -206,6 +294,9 @@
 	faction = FACTION_UA_REBEL
 	friendly_factions = list(
 		FACTION_COLONIST,
+	)
+	neutral_factions = list(
+		FACTION_SURVIVOR,
 	)
 	enter_combat_lines = list(
 		"CONTACT!",
@@ -386,7 +477,7 @@
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
 		FACTION_TWE,
-		FACTION_UPP,
+		FACTION_PMC,
 		FACTION_MERCENARY,
 		FACTION_SURVIVOR,
 	)
@@ -455,14 +546,14 @@
 		FACTION_ARMY,
 		FACTION_NAVY,
 		FACTION_COLONIST,
+		FACTION_MARSHAL,
 	)
 	neutral_factions = list(
-		FACTION_MARSHAL,
 		FACTION_TWE,
 		FACTION_WY,
+		FACTION_PMC,
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
-		FACTION_UPP,
 		FACTION_MERCENARY,
 		FACTION_SURVIVOR,
 	)
@@ -658,14 +749,14 @@
 		FACTION_MARINE,
 		FACTION_NAVY,
 		FACTION_COLONIST,
+		FACTION_MARSHAL,
 	)
 	neutral_factions = list(
-		FACTION_MARSHAL,
 		FACTION_TWE,
 		FACTION_WY,
+		FACTION_PMC,
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
-		FACTION_UPP,
 		FACTION_MERCENARY,
 		FACTION_SURVIVOR,
 	)
@@ -861,14 +952,14 @@
 		FACTION_MARINE,
 		FACTION_ARMY,
 		FACTION_COLONIST,
+		FACTION_MARSHAL,
 	)
 	neutral_factions = list(
-		FACTION_MARSHAL,
 		FACTION_TWE,
 		FACTION_WY,
+		FACTION_PMC,
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
-		FACTION_UPP,
 		FACTION_MERCENARY,
 		FACTION_SURVIVOR,
 	)
@@ -1060,18 +1151,11 @@
 /datum/human_ai_faction/upp
 	faction = FACTION_UPP
 	friendly_factions = list(
-		FACTION_ARMY,
-		FACTION_MARINE,
 		FACTION_COLONIST,
 	)
 	neutral_factions = list(
-		FACTION_TWE,
-		FACTION_WY,
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
-		FACTION_MARINE,
-		FACTION_ARMY,
-		FACTION_NAVY,
 		FACTION_MERCENARY,
 		FACTION_SURVIVOR,
 	)
@@ -1216,23 +1300,32 @@
 		"COVER ME!",
 	)
 
-/datum/human_ai_faction/upp
-	faction = FACTION_UPP
+/datum/human_ai_faction/canc
+	faction = FACTION_CANC
 	friendly_factions = list(
 		FACTION_COLONIST,
-		FACTION_PMC,
+	)
+	neutral_factions = list(
+		FACTION_SURVIVOR,
+	)
+
+/datum/human_ai_faction/wy
+	faction = FACTION_WY
+	friendly_factions = list(
+		FACTION_COLONIST,
 		FACTION_TWE,
-		FACTION_MARINE,
-		FACTION_ARMY,
-		FACTION_NAVY,
+		FACTION_PMC,
+		FACTION_WY_DEATHSQUAD,
 	)
 	neutral_factions = list(
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
+		FACTION_MERCENARY,
 		FACTION_MARINE,
 		FACTION_ARMY,
 		FACTION_NAVY,
-		FACTION_MERCENARY,
+		FACTION_MARSHAL,
+		FACTION_SURVIVOR,
 	)
 
 /datum/human_ai_faction/wy/pmc
@@ -1240,17 +1333,25 @@
 	friendly_factions = list(
 		FACTION_COLONIST,
 		FACTION_TWE,
+		FACTION_WY,
+		FACTION_WY_DEATHSQUAD,
 	)
 	neutral_factions = list(
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
 		FACTION_MERCENARY,
 		FACTION_MARINE,
+		FACTION_ARMY,
+		FACTION_NAVY,
+		FACTION_MARSHAL,
+		FACTION_SURVIVOR,
 	)
+
 /datum/human_ai_faction/wy_deathsquad
 	faction = FACTION_WY_DEATHSQUAD
 	friendly_factions = list(
 		FACTION_WY,
+		FACTION_PMC,
 	)
 	enter_combat_lines = list(
 		"Visual confirmed, engaging.",
@@ -1286,7 +1387,11 @@
 		FACTION_FREELANCER,
 		FACTION_CONTRACTOR,
 		FACTION_MERCENARY,
+		FACTION_SURVIVOR,
 		FACTION_MARINE,
+		FACTION_ARMY,
+		FACTION_NAVY,
+		FACTION_MARSHAL,
 	)
 	enter_combat_lines = list(
 		"CONTACT!",


### PR DESCRIPTION
# About the pull request

Makes WY forces friendly to one another
UA & TWE forces should now be friendly by default
UPP is hostile as standard to UA & TWE forces
Colonists & other factions lacking a hAI faction datum entry have been given one so they don't immediately aggro against _everyone_

# Explain why it's good for the game

Less of a headache for GMs to fix on the fly in rounds if this stuff is set ahead of time

# Testing Photographs and Procedure
Tested on local instance, worked as expected barring some weird 'revenge' shootings when one faction was caught in the crossfire of another

# Changelog

:cl:
qol: Various faction interaction tweaks for hAI
/:cl:

