### PR TITLE
User agents for byond downloads and windows build caching

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -183,6 +183,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Restore BYOND cache
+        uses: actions/cache@v3
+        with:
+          path: C:\\byond
+          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
       - name: Compile
         run: pwsh tools/ci/build.ps1
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y make man
 RUN update-alternatives --install /usr/local/bin/python python /usr/bin/python3 20
 ARG BYOND_MAJOR
 ARG BYOND_MINOR
-ARG BYOND_DOWNLOAD_URL=https://secure.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip
-RUN curl ${BYOND_DOWNLOAD_URL} -o byond.zip \
+ARG BYOND_DOWNLOAD_URL=http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip
+RUN curl ${BYOND_DOWNLOAD_URL} -o byond.zip -A "CMSS13/1.0 Continuous Integration"\
     && unzip byond.zip \
 	&& rm -rf byond.zip
 RUN DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/tools/ci/download_byond.sh
+++ b/tools/ci/download_byond.sh
@@ -2,4 +2,4 @@
 set -e
 source dependencies.sh
 echo "Downloading BYOND version $BYOND_MAJOR.$BYOND_MINOR"
-curl "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip
+curl "http://www.byond.com/download/build/$BYOND_MAJOR/$BYOND_MAJOR.${BYOND_MINOR}_byond.zip" -o C:/byond.zip -A "CMSS13/1.0 Continuous Integration"

--- a/tools/ci/install_byond.sh
+++ b/tools/ci/install_byond.sh
@@ -14,7 +14,7 @@ else
   rm -rf "$HOME/BYOND"
   mkdir -p "$HOME/BYOND"
   cd "$HOME/BYOND"
-  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
+  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip -A "CMSS13/1.0 Continuous Integration"
   unzip byond.zip
   rm byond.zip
   cd byond


### PR DESCRIPTION
# About the pull request

Mirror of https://github.com/cmss13-devs/cmss13/pull/9265

This PR is sort of a port of:
- https://github.com/BeeStation/BeeStation-Hornet/pull/12705
- https://github.com/BeeStation/BeeStation-Hornet/pull/12712
- https://github.com/tgstation/tgstation/pull/91101

Changes done:
- Docker file now uses the same url as the others (if there was a reason this was different let me know but TG didn't have it this way)
- All curls to download byond builds now specify a useragent unique to CM (This is for the AI overlord at cloudflare to trust the request more)
- Windows builds should attempt to cache the build (though it won't be cached if the action is canceled - TG I guess has a different implementation to handle this scenario but its whatever).

~~However, while Byond actually is down, I can't really see if these changes will work so will poke at them when it looks like Byond is available again.~~

# Testing Photographs and Procedure
<details>

- Windows build cache miss: https://github.com/cmss13-devs/cmss13/actions/runs/14956609862/job/42013146369?pr=9265#step:4:9
- Windows build cache hit: https://github.com/cmss13-devs/cmss13/actions/runs/14956676591/job/42013288863?pr=9265#step:4:9
- Docker file: 
![image](https://github.com/user-attachments/assets/d1ac8781-f67c-4d51-beeb-696397018581)

</details>

# Explain why it's good for the game

Passing CI!

# Changelog

No user facing changes.
