### PR TITLE
magazines no longer have locked ammo types

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -39,6 +39,7 @@
 	holo_stacks = 15
 
 /datum/ammo/bullet/rifle/holo_target/tracer
+	name = "tracer holo-targeting 10x24 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -69,11 +70,13 @@
 	penetration = ARMOR_PENETRATION_TIER_8
 
 /datum/ammo/bullet/rifle/ap/tracer
+	name = "tracer armor-piercing 10x24 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
 
 /datum/ammo/bullet/rifle/tracer
+	name = "tracer 10x24 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -128,6 +131,7 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_3
 
 /datum/ammo/bullet/rifle/heap/tracer
+	name = "tracer high-explosive armor-piercing 10x24 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -175,6 +179,7 @@
 		to_chat(P.firer, SPAN_WARNING("Bullseye!"))
 
 /datum/ammo/bullet/rifle/heavy/tracer
+	name = "tracer 10x28 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -186,6 +191,7 @@
 	penetration = ARMOR_PENETRATION_TIER_7
 
 /datum/ammo/bullet/rifle/heavy/ap/tracer
+	name = "tracer armor-piercing 10x28 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -211,6 +217,7 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_3
 
 /datum/ammo/bullet/rifle/heavy/heap/tracer
+	name = "tracer high explosive armor-piercing 10x28 bullet"
 	icon_state = "bullet_red"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -492,6 +499,7 @@
 	penetration = ARMOR_PENETRATION_TIER_2
 
 /datum/ammo/bullet/rifle/ag80/tracer
+	name = "tracer 9.7x16 bullet"
 	icon_state = "bullet_green"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_GREEN
@@ -502,6 +510,7 @@
 	penetration = ARMOR_PENETRATION_TIER_9
 
 /datum/ammo/bullet/rifle/ag80/ap/tracer
+	name = "tracer 9.7x16 bullet"
 	icon_state = "bullet_green"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_RED
@@ -514,6 +523,7 @@
 	shrapnel_chance = SHRAPNEL_CHANCE_TIER_9
 
 /datum/ammo/bullet/rifle/ag80/heap/tracer
+	name = "tracer high-explosive armor-piercing 9.7x16 bullet"
 	icon_state = "bullet_green"
 	ammo_glowing = TRUE
 	bullet_light_color = COLOR_SOFT_GREEN

--- a/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
+++ b/code/modules/projectiles/ammo_boxes/ammo_boxes.dm
@@ -358,7 +358,7 @@
 			to_chat(user, SPAN_WARNING("\The [src] must be on the ground to be used."))
 			return
 		if(AM.flags_magazine & AMMUNITION_REFILLABLE)
-			if(default_ammo != AM.default_ammo)
+			if(default_ammo != AM.default_ammo && AM.current_rounds)
 				to_chat(user, SPAN_WARNING("Those aren't the same rounds. Better not mix them up."))
 				return
 			if(caliber != AM.caliber)
@@ -380,6 +380,7 @@
 					transferable = min(AM.current_rounds, max_bullet_amount - bullet_amount)
 				else
 					transferable = min(bullet_amount, AM.max_rounds - AM.current_rounds)
+					AM.default_ammo = default_ammo
 				if(transferable < 1)
 					to_chat(user, SPAN_NOTICE("You cannot transfer any more rounds."))
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -124,11 +124,8 @@ They're all essentially identical when it comes to getting the job done.
 			if(flags_magazine & AMMUNITION_REFILLABLE) //and a refillable magazine
 				var/obj/item/ammo_magazine/handful/transfer_from = I
 				if(src == user.get_inactive_hand() || bypass_hold_check) //It has to be held.
-					if(default_ammo == transfer_from.default_ammo)
-						if(transfer_ammo(transfer_from,user,transfer_from.current_rounds)) // This takes care of the rest.
-							to_chat(user, SPAN_NOTICE("You transfer rounds to [src] from [transfer_from]."))
-					else
-						to_chat(user, SPAN_NOTICE("Those aren't the same rounds. Better not mix them up."))
+					if(transfer_ammo(transfer_from,user,transfer_from.current_rounds)) // This takes care of the rest.
+						to_chat(user, SPAN_NOTICE("You transfer rounds to [src] from [transfer_from]."))
 				else
 					to_chat(user, SPAN_NOTICE("Try holding [src] before you attempt to restock it."))
 
@@ -141,7 +138,11 @@ They're all essentially identical when it comes to getting the job done.
 	if(source.caliber != caliber) //Are they the same caliber?
 		to_chat(user, "The rounds don't match up. Better not mix them up.")
 		return
-
+	if(source.default_ammo != default_ammo && current_rounds)
+		to_chat(user, "The rounds don't match up. Better not mix them up.")
+		return
+	if(current_rounds <= 0)
+		default_ammo = source.default_ammo
 	var/S = min(transfer_amount, max_rounds - current_rounds)
 	source.current_rounds -= S
 	current_rounds += S
@@ -153,7 +154,6 @@ They're all essentially identical when it comes to getting the job done.
 
 	if(!istype(src, /obj/item/ammo_magazine/internal) && !istype(src, /obj/item/ammo_magazine/shotgun) && !istype(source, /obj/item/ammo_magazine/shotgun)) //if we are shotgun or revolver or whatever not using normal mag system
 		playsound(loc, pick('sound/weapons/handling/mag_refill_1.ogg', 'sound/weapons/handling/mag_refill_2.ogg', 'sound/weapons/handling/mag_refill_3.ogg'), 25, 1)
-
 	update_icon(S)
 	return S // We return the number transferred if it was successful.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

you can now load any ammo types in magazines of same caliber
cant load multiple types tho alas

# Explain why it's good for the game

hpr and stuff can now fire non-tracer rounds also you dont have to find AP mags to fire AP bullets

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Magazines are no longer locked to one specific ammo type, meaning you can load AP ammo into normal mags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
