### PR TITLE
Allows guns to start on the burst-fire firemode

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -254,6 +254,8 @@
 	VAR_PROTECTED/start_semiauto = TRUE
 	/// If this gun should spawn with automatic fire. Protected due to it never needing to be edited.
 	VAR_PROTECTED/start_automatic = FALSE
+	/// If this gun should spawn with burst fire. Protected due to it never needing to be edited.
+	VAR_PROTECTED/start_burstfire = FALSE
 	/// The type of projectile that this gun should shoot
 	var/projectile_type = /obj/projectile
 	/// The multiplier for how much slower this should fire in automatic mode. 1 is normal, 1.2 is 20% slower, 2 is 100% slower, etc. Protected due to it never needing to be edited.

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -720,7 +720,7 @@ DEFINES in setup.dm, referenced here.
 	if(start_semiauto)
 		gun_firemode_list |= GUN_FIREMODE_SEMIAUTO
 
-	if(burst_amount > BURST_AMOUNT_TIER_1)
+	if(start_burstfire || burst_amount > BURST_AMOUNT_TIER_1)
 		gun_firemode_list |= GUN_FIREMODE_BURSTFIRE
 
 	if(!length(gun_firemode_list))


### PR DESCRIPTION
# About the pull request

As the title suggests, adds a flag for weapons to start on burstfire _without_ breaking things

# Explain why it's good for the game

More options for coders looking to add/edit firearms
Atomizes some of the many changes done in #912 into their own PRs instead

# Testing Photographs and Procedure
Tested on local, working as intended
Tested on the RMC PR branch too, as above, working as intended

# Changelog

:cl:
add: Guns can be set to start on burst-fire, provided they're set up for it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
