### PR TITLE
Human Squad Spawner tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_civ.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_civ.dm
@@ -23,8 +23,7 @@
 	name = "Civilian Gathering (UPP)"
 	desc = "A small gathering of UPP colonists."
 	ai_to_spawn = list(
-		/datum/equipment_preset/upp/colonist = 2,
-		/datum/equipment_preset/upp/admin = 1,
+		/datum/equipment_preset/upp/colonist = 3,
 	)
 
 /datum/human_ai_squad_preset/civ/gathering/twe
@@ -160,4 +159,38 @@
 	ai_to_spawn = list(
 		/datum/equipment_preset/colonist/cargo/japanese = 3,
 		/datum/equipment_preset/colonist/operations/japanese = 1,
+	)
+
+// Operations
+
+/datum/human_ai_squad_preset/civ/ops
+	name = "Civilian Operations Group"
+	desc = "A small group of English-speaking UA admin & operations workers."
+	ai_to_spawn = list(
+		/datum/equipment_preset/colonist/admin = 1,
+		/datum/equipment_preset/colonist/operations = 2,
+	)
+
+/datum/human_ai_squad_preset/civ/ops/latam
+	name = "Civilian Operations Group (LatAm)"
+	desc = "A small group of Spanish-speaking UA admin & operations workers."
+	ai_to_spawn = list(
+		/datum/equipment_preset/colonist/admin/spanish = 1,
+		/datum/equipment_preset/colonist/operations/spanish = 2,
+	)
+
+/datum/human_ai_squad_preset/civ/ops/upp
+	name = "Civilian Operations Group (UPP)"
+	desc = "A small group of UPP admin & operations workers."
+	ai_to_spawn = list(
+		/datum/equipment_preset/upp/admin = 1,
+		/datum/equipment_preset/upp/operations = 2,
+	)
+
+/datum/human_ai_squad_preset/civ/ops/twe
+	name = "Civilian Operations Group (TWE)"
+	desc = "A small group of Japanese-speaking TWE admin & operations workers."
+	ai_to_spawn = list(
+		/datum/equipment_preset/colonist/admin/japanese = 1,
+		/datum/equipment_preset/colonist/operations/japanese = 2,
 	)

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_clf.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_clf.dm
@@ -53,7 +53,7 @@
 /datum/human_ai_squad_preset/clf/ua/at
 	name = "UA Rebel, Anti-Tank Team"
 	ai_to_spawn = list(
-/datum/equipment_preset/rebel/at = 1,
+		/datum/equipment_preset/rebel/at = 1,
 		/datum/equipment_preset/rebel/soldier = 1,
 	)
 
@@ -61,7 +61,7 @@
 	name = "UA Rebel, Flamethrower Team"
 	ai_to_spawn = list(
 		/datum/equipment_preset/rebel/soldier = 2,
-	/datum/equipment_preset/rebel/soldier/flamer = 1,
+		/datum/equipment_preset/rebel/soldier/flamer = 1,
 		/datum/equipment_preset/rebel/medic = 1,
 	)
 
@@ -91,6 +91,6 @@
 /datum/human_ai_squad_preset/clf/canc
 	name = "CANC Rebel, Patrol"
 	ai_to_spawn = list(
-		/datum/equipment_preset/canc/remnant = 2,
 		/datum/equipment_preset/canc/remnant/leader = 1,
+		/datum/equipment_preset/canc/remnant = 2,
 	)

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_pmc.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_pmc.dm
@@ -12,17 +12,17 @@
 	name = "PMC, Gun Team"
 	desc = "A PMC squad, with support elements and a leader."
 	ai_to_spawn = list(
-		/datum/equipment_preset/pmc/pmc_standard = 1,
 		/datum/equipment_preset/pmc/pmc_gunner = 1,
+		/datum/equipment_preset/pmc/pmc_standard = 1,
 	)
 
 /datum/human_ai_squad_preset/pmc/squad
 	name = "PMC, Squad"
 	desc = "A PMC squad, with support elements, a heavy smartgunner, and a leader. Use carefully."
 	ai_to_spawn = list(
-		/datum/equipment_preset/pmc/pmc_standard = 2,
-		/datum/equipment_preset/pmc/pmc_gunner = 1,
 		/datum/equipment_preset/pmc/pmc_leader = 1,
+		/datum/equipment_preset/pmc/pmc_gunner = 1,
+		/datum/equipment_preset/pmc/pmc_standard = 2,
 	)
 
 /datum/human_ai_squad_preset/pmc/medical

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_upp.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_upp.dm
@@ -43,9 +43,9 @@
 	name = "Naval Infantry, Command Element"
 	desc = "Naval Infantry team armed with 2 AG80 rifles and 1 Type 71 rifle. Best utilized as defended objective, PltCo is not armed effectively."
 	ai_to_spawn = list(
-		/datum/equipment_preset/upp/rifleman/ag80 = 2,
-		/datum/equipment_preset/upp/navallead = 1,
 		/datum/equipment_preset/upp/officer/naval = 1,
+		/datum/equipment_preset/upp/navallead = 1,
+		/datum/equipment_preset/upp/rifleman/ag80 = 2,
 	)
 
 /datum/human_ai_squad_preset/upp/gunner

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_uscm.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_uscm.dm
@@ -6,25 +6,25 @@
 	name = "USCM, Rifle Team"
 	desc = "USCM patrol armed with M41A rifles and carrying IFAKs containing gauze, ointment, splints and an injector."
 	ai_to_spawn = list(
-		/datum/equipment_preset/uscm/private_equipped = 1,
 		/datum/equipment_preset/uscm/tl_equipped = 1,
+		/datum/equipment_preset/uscm/private_equipped = 1,
 	)
 
 /datum/human_ai_squad_preset/uscm/gunteam
 	name = "USCM, Gun Team"
 	desc = "USCM patrol armed with a M41A rifle and an M56A2 smartgun, and carrying IFAKs containing gauze, ointment, splints and an injector."
 	ai_to_spawn = list(
-		/datum/equipment_preset/uscm/private_equipped = 1,
 		/datum/equipment_preset/uscm/smartgunner_equipped = 1,
+		/datum/equipment_preset/uscm/private_equipped = 1,
 	)
 
 /datum/human_ai_squad_preset/uscm/squad
 	name = "USCM, Squad"
 	desc = "USCM patrol armed with 3 M41A rifle and an M56A2 smartgun, and carrying IFAKs containing gauze, ointment, splints and an injector."
 	ai_to_spawn = list(
-		/datum/equipment_preset/uscm/private_equipped = 2,
-		/datum/equipment_preset/uscm/smartgunner_equipped = 1,
 		/datum/equipment_preset/uscm/tl_equipped = 1,
+		/datum/equipment_preset/uscm/smartgunner_equipped = 1,
+		/datum/equipment_preset/uscm/private_equipped = 2,
 	)
 
 /datum/human_ai_squad_preset/uscm/medical
@@ -38,8 +38,8 @@
 	name = "USCM, Command Element"
 	desc = "Best utilized as defended objective, PltCo is not armed effectively."
 	ai_to_spawn = list(
-		/datum/equipment_preset/uscm/private_equipped = 2,
-		/datum/equipment_preset/uscm/leader_equipped = 1,
 		/datum/equipment_preset/uscm_ship/so_equipped = 1,
+		/datum/equipment_preset/uscm/leader_equipped = 1,
+		/datum/equipment_preset/uscm/private_equipped = 2,
 	)
 

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_wy.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_wy.dm
@@ -19,6 +19,6 @@
 	name = "W-Y Security, Tactical Squad"
 	desc = "A squad comprised of 2 corporate tactical response officers armed with M39s and 1 corporate tactical response officer armed with a HG-37 loaded with slugs."
 	ai_to_spawn = list(
-		/datum/equipment_preset/colonist/security/weyland/tactical = 2,
 		/datum/equipment_preset/colonist/security/weyland/tactical/lead = 1,
+		/datum/equipment_preset/colonist/security/weyland/tactical = 2,
 	)

--- a/tgui/packages/tgui/interfaces/HumanSquadSpawner.tsx
+++ b/tgui/packages/tgui/interfaces/HumanSquadSpawner.tsx
@@ -25,7 +25,7 @@ export const HumanSquadSpawner = (props) => {
         <Stack fill vertical>
           <Stack fill>
             <Stack.Item grow mr={1}>
-              <Section fill height="100%">
+              <Section fill scrollable>
                 {Object.keys(squads).map((dictKey) => (
                   <Collapsible title={dictKey} key={dictKey} color="good">
                     {squads[dictKey].map((squad) => (


### PR DESCRIPTION
# About the pull request

Added a scrolling bar to the UI panel, thanks to guidance from @kwaize aka MistChristmas. Added new civilian squad type to all 4 subgroups, "Operations", which includes an Admin and two Operations hAI. I removed an admin from the UPP civilian list and replaced it with a regular civ - was weird to me that you couldn't spam UPP civilians without there being a dozen administrators. 

Updated some lists in the spawner as the first listed hAI is the 'squad leader' and it was annoying me that, for example, the UPP command element wouldn't follow the officer. 

# Explain why it's good for the game

Scrolling bar makes the panel easier to navigate. UPP civilians can now be better placed without worrying about excess admins. Squads in general have a better defined command structure for squad leader purposes. 

# Testing Photographs and Procedure

tested locally

# Changelog

:cl:
add: Added Civilian Squad of Operations to all 4 subgroups (UA, UA LatAm, UPP and TWE)
qol: Did a pass at updating all the squad makeups to make sure the right prop was being made the squad leader 
fix: Removed the Admin from the UPP Civilian squad, and replaced with another civilian
ui: added scrolling bar to human squad spawner
/:cl:
