### PR TITLE
queen caste buffs

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -314,7 +314,7 @@
 #define XENO_EVASION_HIGH 20
 
 // Speeds
-#define XENO_SPEED_QUEEN 0.6
+#define XENO_SPEED_QUEEN 0.5
 #define XENO_SPEED_TIER_1 0.4
 #define XENO_SPEED_TIER_2 0.2
 #define XENO_SPEED_TIER_3 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -6,14 +6,14 @@
 	caste_type = XENO_CASTE_QUEEN
 	tier = 0
 
-	melee_damage_lower = XENO_DAMAGE_TIER_4
-	melee_damage_upper = XENO_DAMAGE_TIER_6
+	melee_damage_lower = XENO_DAMAGE_TIER_5
+	melee_damage_upper = XENO_DAMAGE_TIER_7
 	melee_vehicle_damage = XENO_DAMAGE_TIER_9 //Queen and Ravs have extra multiplier when dealing damage in multitile_interaction.dm
-	max_health = XENO_HEALTH_QUEEN
+	max_health = XENO_HEALTH_QUEEN * 5 // PVE boss edition
 	plasma_gain = XENO_PLASMA_GAIN_TIER_7
-	plasma_max = XENO_PLASMA_TIER_10
+	plasma_max = XENO_PLASMA_TIER_10 * 3 // PVE boss edition
 	xeno_explosion_resistance = XENO_EXPLOSIVE_ARMOR_TIER_10
-	armor_deflection = XENO_ARMOR_TIER_2
+	armor_deflection = XENO_ARMOR_TIER_4
 	evasion = XENO_EVASION_NONE
 	speed = XENO_SPEED_QUEEN
 


### PR DESCRIPTION
# About the pull request

Queen caste is woefully weak in PvE and is usually VV edited by GMs anyway when utilised. This would just help lessen the time GMs need to take in terms of fixing them. 

# Explain why it's good for the game

Queen is scarier. Not as strong as PvE King but stronger. Dangerous for a section of players to face but not unkillable. 

# Testing Photographs and Procedure

tested locally

# Changelog

:cl:
balance: Upped queen's speed a smidge. Quadrupled her health max. Tripled her plasma max. Upped her armor and damage tiers. 
/:cl:
