### PR TITLE
ERT default user selectionfix

### DIFF
--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -285,12 +285,12 @@
 			em_call.owner = owner
 
 			var/quiet_launch = TRUE
-			var/ql_prompt = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+			var/ql_prompt = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("No", "Yes"), 20 SECONDS)
 			if(ql_prompt == "Yes")
 				quiet_launch = FALSE
 
 			var/announce_receipt = FALSE
-			var/ar_prompt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), 20 SECONDS)
+			var/ar_prompt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("No", "Yes"), 20 SECONDS)
 			if(ar_prompt == "Yes")
 				announce_receipt = TRUE
 


### PR DESCRIPTION
# About the pull request

PvE Create Humans ERT flow - GMs almost never want to announce this to existing players. Just changing the default picks to No. 

# Explain why it's good for the game

Helps avoid GMs forgetting to hit no 

# Testing Photographs and Procedure

tested locally BUT i did notice that the roundstart UI panel (ready up, observe etc) was fucked up and idk if that's on me cos damn son I swapped some stuff around that's it 


# Changelog

:cl:
qol: swapped the Create Humans - ERT default selection around in their pop ups
/:cl:
