### PR TITLE
Human AI now Compare Vehicle Factions to their Neutral and Friendly Factions.

### DIFF
--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_helpers.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_helpers.dm
@@ -52,7 +52,16 @@
 
 		if(mob_target.faction in neutral_factions)
 			return TRUE
+	if(istype(target, /obj/vehicle/multitile))
+		var/obj/vehicle/multitile/vehicle_target = target
+		if(vehicle_target.vehicle_faction == tied_human.faction)
+			return TRUE
 
+		if(vehicle_target.vehicle_faction in friendly_factions)
+			return TRUE
+
+		if(vehicle_target.vehicle_faction in neutral_factions)
+			return TRUE
 	if(isdefenses(target))
 		var/obj/structure/machinery/defenses/defense_target = target
 		if(tied_human.faction in defense_target.faction_group)

--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_targeting.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_targeting.dm
@@ -78,7 +78,7 @@
 		if(potential_vehicle_target.health <= 0)
 			continue
 
-		if(potential_vehicle_target.vehicle_faction == tied_human.faction)
+		if(faction_check(potential_vehicle_target))
 			continue
 
 		viable_targets += potential_vehicle_target

--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_targeting.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_targeting.dm
@@ -78,6 +78,14 @@
 		if(potential_vehicle_target.health <= 0)
 			continue
 
+		var/all_broken = TRUE
+		for(var/obj/item/hardpoint/H in potential_vehicle_target.hardpoints)
+			if(H.can_take_damage())
+				all_broken = FALSE
+
+		if(all_broken)
+			continue
+
 		if(faction_check(potential_vehicle_target))
 			continue
 

--- a/code/modules/mob/living/carbon/human/ai/brain/ai_brain_targeting.dm
+++ b/code/modules/mob/living/carbon/human/ai/brain/ai_brain_targeting.dm
@@ -78,14 +78,6 @@
 		if(potential_vehicle_target.health <= 0)
 			continue
 
-		var/all_broken = TRUE
-		for(var/obj/item/hardpoint/H in potential_vehicle_target.hardpoints)
-			if(H.can_take_damage())
-				all_broken = FALSE
-
-		if(all_broken)
-			continue
-
 		if(faction_check(potential_vehicle_target))
 			continue
 


### PR DESCRIPTION

# About the pull request

Human Ai now check if the faction of a vehicle is the same, friendly or neutral to them.
Before they would only check if the faction was the same, which made them always shoot vehicles of otherwise friendly or neutral players as defined by the GM in the faction manager panel.
As a reminder, vehicles faction and IFF are based on the faction of the last human to have used the driver seat.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

Fixes an oversight. Makes it not needed to var edit a vehicle to stop Human Ai shooting at what you may have already designated as a friendly faction

# Changelog
:cl:
fix: Human AI now check if a vehicle is in their friendly or neutral factions before targeting.
/:cl:
