### PR TITLE
Made some neckwear size small

### DIFF
--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -129,6 +129,7 @@
 	icon_state = "scarf_gray"
 	item_state = "scarf_gray"
 	original_state = "scarf_gray"
+	w_class = SIZE_SMALL
 	flags_inventory = COVERMOUTH|ALLOWREBREATH|ALLOWCPR
 	flags_inv_hide = HIDEFACE|HIDELOWHAIR
 	flags_cold_protection = BODY_FLAG_HEAD
@@ -228,6 +229,7 @@
 	item_icons = list(
 		WEAR_FACE = 'icons/mob/humans/onmob/mask.dmi'
 	)
+	w_class = SIZE_SMALL
 	flags_inventory = ALLOWREBREATH|ALLOWCPR
 	var/adjust = FALSE
 	var/original_state = "neckerchief"


### PR DESCRIPTION
# About the pull request

Noticed that a neckerchief was bigger than a gasmask. Was just defaulting to size medium. GIven some neckwear size small. 

# Explain why it's good for the game

A neckerchief should not be a bigger weight class than a gas mask.

# Testing Photographs and Procedure
tested locally.

# Changelog

:cl:
fix: fixed missing weight class on some neckwear
/:cl:
