### PR TITLE
AG80 Fixes

### DIFF
--- a/code/datums/ammo/bullet/rifle.dm
+++ b/code/datums/ammo/bullet/rifle.dm
@@ -492,7 +492,7 @@
 /datum/ammo/bullet/rifle/ag80
 	name = "9.7x16 bullet"
 	damage = 35
-	penetration = ARMOR_PENETRATION_TIER_2
+	penetration = ARMOR_PENETRATION_TIER_1 // shouldn't be higher pen than 10x24
 
 /datum/ammo/bullet/rifle/ag80/tracer
 	icon_state = "bullet_green"
@@ -502,7 +502,7 @@
 /datum/ammo/bullet/rifle/ag80/ap
 	name = "armor-piercing 9.7x16 bullet"
 	damage = 35
-	penetration = ARMOR_PENETRATION_TIER_9
+	penetration = ARMOR_PENETRATION_TIER_7 // not as good as 10x24 AP but still impressive for calibre size
 
 /datum/ammo/bullet/rifle/ag80/ap/tracer
 	icon_state = "bullet_green"
@@ -513,8 +513,8 @@
 	name = "high-explosive armor-piercing 9.7x16 bullet"
 	headshot_state = HEADSHOT_OVERLAY_HEAVY
 	damage = 50 //big damage, doesn't actually blow up because thats stupid.
-	penetration = ARMOR_PENETRATION_TIER_8
-	shrapnel_chance = SHRAPNEL_CHANCE_TIER_9
+	penetration = ARMOR_PENETRATION_TIER_7
+	shrapnel_chance = SHRAPNEL_CHANCE_TIER_2 //thinner round should have less shrap potential vs the 10x24, no?
 
 /datum/ammo/bullet/rifle/ag80/heap/tracer
 	icon_state = "bullet_green"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -411,7 +411,7 @@
 
 /obj/item/weapon/gun/rifle/ag80
 	name = "\improper AG80 pulse rifle"
-	desc = "Pulse action 9.7x16mm caseless assault rifle of the UPPAC Naval Infantry. Only recently entered service and has yet to see full integration."
+	desc = "Pulse action 9.7x16mm caseless assault rifle of the UPPAC Naval Infantry. Only recently entered service and has yet to see full integration. The design suggests that it is a carbine sibling to the Type-71's rifle role, rather than an outright replacement."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/upp.dmi'
 	icon_state = "ag80"
 	item_state = "ag80"

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -335,7 +335,7 @@
 	icon_state = "ag80"
 	ammo_band_icon = "+ag80_band"
 	ammo_band_icon_empty = "+ag80_band_e"
-	default_ammo = /datum/ammo/bullet/rifle
+	default_ammo = /datum/ammo/bullet/rifle/ag80 //need to reference the actual ammo designed for the carbine
 	max_rounds = 99
 	gun_type = /obj/item/weapon/gun/rifle/ag80
 


### PR DESCRIPTION
# About the pull request

Step1 - get the AG80 rifle to reference the correct bullet type rather than falling back on the 10x24...
Step2 - nerf the AG80's base states just a smidge since after all, 9.7x16 IS a smaller round vs the 10x24

# Explain why it's good for the game

Make the AG80 not as insanely powerful as it currently is. It has DPS that outstrips the Type71 pre-this PR. 


# Testing Photographs and Procedure
tested locally

# Changelog

:cl:
balance: Reduced AG80 rounds armor pen (2->1 for normal, 9->7 for AP) and shrapnel chance for HEAP (9->2)
fix: AG80 actually references the right bullet type now
ui: changed something relating to user interfaces
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
