### PR TITLE
Power repaired announcer in Events panel silenced

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -24,7 +24,7 @@
 	if(announce)
 		marine_announcement("Abnormal activity detected in the ship power system. As a precaution, power must be shut down for an indefinite duration.", "Critical Power Failure", 'sound/AI/poweroff.ogg')
 
-/proc/power_restore(announce = 1)
+/proc/power_restore(announce = 0)
 	for(var/obj/structure/machinery/power/smes/S in GLOB.machines)
 		if(!is_mainship_level(S.z))
 			continue
@@ -42,7 +42,7 @@
 	if(announce)
 		marine_announcement("Power has been restored. Reason: Unknown.", "Power Systems Nominal", 'sound/AI/poweron.ogg')
 
-/proc/power_restore_quick(announce = 1)
+/proc/power_restore_quick(announce = 0)
 
 	for(var/obj/structure/machinery/power/smes/S in GLOB.machines)
 		if(!is_mainship_level(S.z)) // Ship only
@@ -57,7 +57,7 @@
 	if(announce)
 		marine_announcement("Power has been restored. Reason: Unknown.", "Power Systems Nominal", 'sound/AI/poweron.ogg')
 
-/proc/power_restore_everything(announce = 1)
+/proc/power_restore_everything(announce = 0)
 
 	for(var/obj/structure/machinery/power/smes/S in GLOB.machines)
 		S.charge = S.capacity


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
More of a GM facing PR, shuts the 'Power has been restored' announcer up so GMs can try to fix power issues without a loud announcer screaming about it across the server. 

Keeps the one for the ship map since this one might actually have use. 
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
config: Silences the announcer for power restoration in Events Panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
