### PR TITLE
Port: Fix for Call and Response emotes, (Rock Paper Scissors etc.) 

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -290,11 +290,11 @@
 #define PANDEMIC 2
 
 //emote flags
-#define EMOTING_HIGH_FIVE  1
-#define EMOTING_FIST_BUMP  2
-#define EMOTING_HEADBUTT   3
-#define EMOTING_TAIL_SWIPE 4
-#define EMOTING_ROCK_PAPER_SCISSORS 5
+#define EMOTING_HIGH_FIVE  (1<<0)
+#define EMOTING_FIST_BUMP  (1<<1)
+#define EMOTING_HEADBUTT   (1<<2)
+#define EMOTING_TAIL_SWIPE (1<<3)
+#define EMOTING_ROCK_PAPER_SCISSORS (1<<4)
 
 //forcesay types
 #define SUDDEN 0

--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -93,110 +93,116 @@
 
 //Hot hot Aliens on Aliens action.
 //Actually just used for eating people.
-/mob/living/carbon/xenomorph/attack_alien(mob/living/carbon/xenomorph/M)
-	if (M.fortify || HAS_TRAIT(M, TRAIT_ABILITY_BURROWED))
+/mob/living/carbon/xenomorph/attack_alien(mob/living/carbon/xenomorph/xeno)
+	if (xeno.fortify || HAS_TRAIT(xeno, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
 	if(HAS_TRAIT(src, TRAIT_ABILITY_BURROWED))
 		return XENO_NO_DELAY_ACTION
 
-	if(islarva(M)) //Larvas can't eat people
-		M.visible_message(SPAN_DANGER("[M] nudges its head against \the [src]."), \
+	if(islarva(xeno)) //Larvas can't eat people
+		xeno.visible_message(SPAN_DANGER("[xeno] nudges its head against \the [src]."),
 		SPAN_DANGER("We nudge our head against \the [src]."), null, null, CHAT_TYPE_XENO_FLUFF)
 		return
 
-	switch(M.a_intent)
+	switch(xeno.a_intent)
 		if(INTENT_HELP)
 			if(on_fire)
-				extinguish_mob(M)
-			else if(M.zone_selected == "head")
-				M.attempt_headbutt(src)
+				extinguish_mob(xeno)
+			else if(flags_emote & EMOTING_HEADBUTT)
+				xeno.attempt_headbutt(src)
 				return XENO_NONCOMBAT_ACTION
-			else if(M.zone_selected == "groin")
-				M.attempt_tailswipe(src)
+			else if(flags_emote & EMOTING_TAIL_SWIPE)
+				xeno.attempt_tailswipe(src)
+				return XENO_NONCOMBAT_ACTION
+			else if(xeno.zone_selected == "head")
+				xeno.attempt_headbutt(src)
+				return XENO_NONCOMBAT_ACTION
+			else if(xeno.zone_selected == "groin")
+				xeno.attempt_tailswipe(src)
 				return XENO_NONCOMBAT_ACTION
 			else
-				M.visible_message(SPAN_NOTICE("\The [M] caresses \the [src] with its claws."), \
+				xeno.visible_message(SPAN_NOTICE("\The [xeno] caresses \the [src] with its claws."),
 				SPAN_NOTICE("We caress \the [src] with our claws."), null, 5, CHAT_TYPE_XENO_FLUFF)
 
 		if(INTENT_GRAB)
-			if(M == src || anchored)
+			if(xeno == src || anchored)
 				return XENO_NO_DELAY_ACTION
 
-			if(Adjacent(M)) //Logic!
-				M.start_pulling(src)
+			if(Adjacent(xeno)) //Logic!
+				xeno.start_pulling(src)
 
-				M.visible_message(SPAN_WARNING("[M] grabs \the [src]!"), \
+				xeno.visible_message(SPAN_WARNING("[xeno] grabs \the [src]!"),
 				SPAN_WARNING("You grab \the [src]!"), null, 5, CHAT_TYPE_XENO_FLUFF)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 
 		if(INTENT_HARM)
-			if(M.behavior_delegate && M.behavior_delegate.handle_slash(src))
+			if(xeno.behavior_delegate && xeno.behavior_delegate.handle_slash(src))
 				return XENO_NO_DELAY_ACTION
 
 			if(stat == DEAD)
-				to_chat(M, SPAN_WARNING("[src] is dead, why would you want to touch it?"))
+				to_chat(xeno, SPAN_WARNING("[src] is dead, why would you want to touch it?"))
 				return XENO_NO_DELAY_ACTION
 
-			if(M.can_not_harm(src))
+			if(xeno.can_not_harm(src))
 				return XENO_NO_DELAY_ACTION
 
-			M.animation_attack_on(src)
+			xeno.animation_attack_on(src)
 
 			// copypasted from attack_alien.dm
 			//From this point, we are certain a full attack will go out. Calculate damage and modifiers
-			M.track_slashes(M.caste_type) //Adds to slash stat.
-			var/damage = get_xeno_damage_slash(src, rand(M.melee_damage_lower, M.melee_damage_upper))
+			xeno.track_slashes(xeno.caste_type) //Adds to slash stat.
+			var/damage = get_xeno_damage_slash(src, rand(xeno.melee_damage_lower, xeno.melee_damage_upper))
 
-			if(M.behavior_delegate)
-				damage = M.behavior_delegate.melee_attack_modify_damage(damage, src)
+			if(xeno.behavior_delegate)
+				damage = xeno.behavior_delegate.melee_attack_modify_damage(damage, src)
 
 			//Frenzy auras stack in a way, then the raw value is multipled by two to get the additive modifier
-			if(M.frenzy_aura > 0)
-				damage += (M.frenzy_aura * FRENZY_DAMAGE_MULTIPLIER)
+			if(xeno.frenzy_aura > 0)
+				damage += (xeno.frenzy_aura * FRENZY_DAMAGE_MULTIPLIER)
 
 			//Somehow we will deal no damage on this attack
 			if(!damage)
-				playsound(M.loc, 'sound/weapons/alien_claw_swipe.ogg', 25, 1)
-				M.visible_message(SPAN_DANGER("\The [M] lunges at [src]!"), \
+				playsound(xeno.loc, 'sound/weapons/alien_claw_swipe.ogg', 25, 1)
+				xeno.visible_message(SPAN_DANGER("\The [xeno] lunges at [src]!"),
 				SPAN_DANGER("You lunge at [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 				return XENO_ATTACK_ACTION
 
-			M.visible_message(SPAN_DANGER("\The [M] [slashes_verb] [src]!"), \
+			xeno.visible_message(SPAN_DANGER("\The [xeno] [slashes_verb] [src]!"),
 			SPAN_DANGER("You [slash_verb] [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
-			last_damage_data = create_cause_data(initial(M.name), M)
-			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was [slash_verb]ed by [key_name(M)]</font>")
-			M.attack_log += text("\[[time_stamp()]\] <font color='red'>[slash_verb]ed [key_name(src)]</font>")
-			log_attack("[key_name(M)] [slash_verb]ed [key_name(src)]")
+			last_damage_data = create_cause_data(initial(xeno.name), xeno)
+			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was [slash_verb]ed by [key_name(xeno)]</font>")
+			xeno.attack_log += text("\[[time_stamp()]\] <font color='red'>[slash_verb]ed [key_name(src)]</font>")
+			log_attack("[key_name(xeno)] [slash_verb]ed [key_name(src)]")
 
-			M.flick_attack_overlay(src, "slash")
+			xeno.flick_attack_overlay(src, "slash")
 			if(custom_slashed_sound)
 				playsound(loc, custom_slashed_sound, 25, 1)
 			else
 				playsound(loc, slash_sound, 25, 1)
 			apply_armoured_damage(damage, ARMOR_MELEE, BRUTE, effectiveness_mult = XVX_ARMOR_EFFECTIVEMULT)
 
-			if(M.behavior_delegate)
-				var/datum/behavior_delegate/MD = M.behavior_delegate
+			if(xeno.behavior_delegate)
+				var/datum/behavior_delegate/MD = xeno.behavior_delegate
 				MD.melee_attack_additional_effects_target(src)
 				MD.melee_attack_additional_effects_self()
 
-			SEND_SIGNAL(M, COMSIG_XENO_ALIEN_ATTACK, src)
+			SEND_SIGNAL(xeno, COMSIG_XENO_ALIEN_ATTACK, src)
 
 		if(INTENT_DISARM)
-			M.animation_attack_on(src)
-			M.flick_attack_overlay(src, "disarm")
-			var/is_shover_queen = isqueen(M)
-			var/can_resist_shove = M.hivenumber != src.hivenumber || ((isqueen(src) || IS_XENO_LEADER(src)) && !is_shover_queen)
-			var/can_mega_shove = is_shover_queen || IS_XENO_LEADER(M)
-			if(can_mega_shove && !can_resist_shove || (mob_size < MOB_SIZE_XENO_SMALL && M.mob_size >= MOB_SIZE_XENO_SMALL))
+			xeno.animation_attack_on(src)
+			xeno.flick_attack_overlay(src, "disarm")
+			var/is_shover_queen = isqueen(xeno)
+			var/can_resist_shove = xeno.hivenumber != src.hivenumber || ((isqueen(src) || IS_XENO_LEADER(src)) && !is_shover_queen)
+			var/can_mega_shove = is_shover_queen || IS_XENO_LEADER(xeno)
+			if(can_mega_shove && !can_resist_shove || (mob_size < MOB_SIZE_XENO_SMALL && xeno.mob_size >= MOB_SIZE_XENO_SMALL))
 				playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
-				M.visible_message(SPAN_WARNING("\The [M] shoves \the [src] out of her way!"), \
+				xeno.visible_message(SPAN_WARNING("\The [xeno] shoves \the [src] out of her way!"),
 				SPAN_WARNING("We shove \the [src] out of our way!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 				src.apply_effect(1, WEAKEN)
 			else
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1)
-				M.visible_message(SPAN_WARNING("\The [M] shoves \the [src]!"), \
+				xeno.visible_message(SPAN_WARNING("\The [xeno] shoves \the [src]!"),
 				SPAN_WARNING("We shove \the [src]!"), null, 5, CHAT_TYPE_XENO_COMBAT)
 	return XENO_ATTACK_ACTION
 


### PR DESCRIPTION
# About the pull request
Ports: 
- https://github.com/cmss13-devs/cmss13/pull/8307

Fixes: #1028

Also kills some one letter vars whilst I'm copy pasting
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
Players can now lose at rock paper scissors instead of just high fiving and refusing to lose
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl: ihatethisengine
fix: Respondable Emotes don't default to High Five
/:cl:
