### PR TITLE
Adds more grenades

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1019,9 +1019,9 @@
 		WEAR_L_HAND = "s_marinebelt",
 		WEAR_R_HAND = "s_marinebelt")
 	w_class = SIZE_LARGE
-	storage_slots = 12
+	storage_slots = 15
 	max_w_class = SIZE_MEDIUM
-	max_storage_space = 24
+	max_storage_space = 30
 	can_hold = list(/obj/item/explosive/grenade)
 
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -1019,9 +1019,8 @@
 		WEAR_L_HAND = "s_marinebelt",
 		WEAR_R_HAND = "s_marinebelt")
 	w_class = SIZE_LARGE
-	storage_slots = 15
+	storage_slots = 14
 	max_w_class = SIZE_MEDIUM
-	max_storage_space = 30
 	can_hold = list(/obj/item/explosive/grenade)
 
 

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -1468,7 +1468,7 @@
 	hold = /obj/item/storage/internal/accessory/black_vest/m3grenade
 
 /obj/item/storage/internal/accessory/black_vest/m3grenade
-	storage_slots = 7
+	storage_slots = 10
 	can_hold = list(
 		/obj/item/explosive/grenade/high_explosive,
 		/obj/item/explosive/grenade/high_explosive/super,

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -1468,7 +1468,7 @@
 	hold = /obj/item/storage/internal/accessory/black_vest/m3grenade
 
 /obj/item/storage/internal/accessory/black_vest/m3grenade
-	storage_slots = 10
+	storage_slots = 7
 	can_hold = list(
 		/obj/item/explosive/grenade/high_explosive,
 		/obj/item/explosive/grenade/high_explosive/super,

--- a/maps/map_files/golden_arrow/golden_arrow.dmm
+++ b/maps/map_files/golden_arrow/golden_arrow.dmm
@@ -17667,15 +17667,20 @@
 /area/golden_arrow/synthcloset)
 "kBG" = (
 /obj/structure/surface/table/reinforced/almayer_B,
-/obj/item/ammo_box/magazine/nade_box{
-	pixel_y = 13;
-	layer = 3.2
-	},
 /obj/item/storage/box/guncase/heavy/sentry{
 	pixel_y = 13
 	},
 /obj/item/storage/box/guncase/heavy/sentry,
 /obj/structure/machinery/power/apc/almayer/east,
+/obj/item/ammo_box/magazine/nade_box{
+	pixel_y = 13;
+	layer = 3.2
+	},
+/obj/item/ammo_box/magazine/nade_box{
+	pixel_y = 20;
+	layer = 3.2;
+	pixel_x = 3
+	},
 /turf/open/floor/almayer,
 /area/golden_arrow/platoonarmory)
 "kDp" = (


### PR DESCRIPTION
# About the pull request
Adds another grenade box and buffs the grenade belt and webbing.
# Explain why it's good for the game
Each box of grenades holds 25 grenades, there are currently two boxes of grenades on the Golden Arrow. There are ten marines, each of which have an under barrel grenade launcher which can hold 5 grenades. If you do some simple math, you cannot take any explosive storage without taking somebody else's UBGL load, so adding another box (or two if you'll let me) would be for the better.
Grenade belt was buffed to have two full rows because it looks silly otherwise.
# Changelog
:cl:
qol: Gave the Golden Arrow an extra box of grenades so you can take more than one UBGL load without taking somebody else's
balance: Buffed the grenade belt to 14 grenades
/:cl: