### PR TITLE
All Marines can use the Weapons Console on the Dropship

### DIFF
--- a/code/game/machinery/computer/dropship_weapons.dm
+++ b/code/game/machinery/computer/dropship_weapons.dm
@@ -883,25 +883,25 @@
 
 /obj/structure/machinery/computer/dropship_weapons/dropship1
 	name = "\improper 'Alamo' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_ALAMO
 
 /obj/structure/machinery/computer/dropship_weapons/dropship2
 	name = "\improper 'Normandy' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_NORMANDY
 
 /obj/structure/machinery/computer/dropship_weapons/dropship3
 	name = "\improper 'Saipan' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_SAIPAN
 
 /obj/structure/machinery/computer/dropship_weapons/midway
 	name = "\improper 'Midway' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_MIDWAY
 
@@ -912,7 +912,7 @@
 
 /obj/structure/machinery/computer/dropship_weapons/cyclone
 	name = "\improper 'Cyclone' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_CYCLONE
 
@@ -923,7 +923,7 @@
 
 /obj/structure/machinery/computer/dropship_weapons/tornado
 	name = "\improper 'Tornado' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_TORNADO
 
@@ -934,7 +934,7 @@
 
 /obj/structure/machinery/computer/dropship_weapons/typhoon
 	name = "\improper 'Typhoon' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_TYPHOON
 
@@ -945,7 +945,7 @@
 
 /obj/structure/machinery/computer/dropship_weapons/tripoli
 	name = "\improper 'Tripoli' weapons controls"
-	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT)
+	req_one_access = list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_WY_FLIGHT, ACCESS_MARINE_PREP)
 	firemission_envelope = new /datum/cas_fire_envelope/uscm_dropship()
 	shuttle_tag = DROPSHIP_TRIPOLI
 

--- a/maps/shuttles/dropship_pmc.dmm
+++ b/maps/shuttles/dropship_pmc.dmm
@@ -234,7 +234,8 @@
 /obj/structure/machinery/computer/dropship_weapons/midway/small{
 	pixel_y = 8;
 	pixel_x = 8;
-	name = "\improper 'Cash Flow' weapons controls"
+	name = "\improper 'Cash Flow' weapons controls";
+	req_one_access = list(12,22,205, 200)
 	},
 /obj/structure/bed/chair/vehicle/dropship_cockpit/copilot{
 	dir = 1;

--- a/maps/shuttles/dropship_upp.dmm
+++ b/maps/shuttles/dropship_upp.dmm
@@ -155,7 +155,7 @@
 	name = "\improper 'Akademia Nauk' weapons controls";
 	shuttle_tag = "dropship_upp";
 	faction = "UPP";
-	req_one_access = list(235,240)
+	req_one_access = list(230, 235,240)
 	},
 /obj/structure/blocker/invisible_wall,
 /turf/open/floor/strata/floor3/east,


### PR DESCRIPTION

# About the pull request


Add marine prep access to the dropship consoles so they can use the tacmap and signal flare view.

# Explain why it is good for the game
Not dependant for a specific prop to look at the tac-map right before evac.

# Changelog
:cl:
balance: All marines can now use the weapons console on the dropship. Primarily for the live tac map.
/:cl:
