### PR TITLE
Triple the TGUI chatlog Highlight Limit

### DIFF
--- a/tgui/packages/tgui-panel/settings/constants.ts
+++ b/tgui/packages/tgui-panel/settings/constants.ts
@@ -36,4 +36,4 @@ export const FONTS = [
   'Lucida Console',
 ];
 
-export const MAX_HIGHLIGHT_SETTINGS = 10;
+export const MAX_HIGHLIGHT_SETTINGS = 30;


### PR DESCRIPTION

# About the pull request


Makes the chat highlight entry limit 30 instead of 10, so there can be 30 different colours and sets of conditions.

# Explain why it's good for the game
You can have more colour in your chatlog.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
ui: Increased the TGUI chatlog highlight entry limit from 10 to 30.
/:cl:
