### PR TITLE
bootless knives... wait- no- THE OTHER WAY AROUND- FU-

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -100,7 +100,7 @@
 /obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep/populate_product_list(scale)
 	listed_products = list(
 		list("STANDARD EQUIPMENT", -1, null, null, null),
-		list("Marine Jungle Boots", floor(scale * 15), /obj/item/clothing/shoes/marine/jungle/knife, VENDOR_ITEM_REGULAR),
+		list("Marine Jungle Boots", floor(scale * 15), /obj/item/clothing/shoes/marine/jungle, VENDOR_ITEM_REGULAR),
 		list("Marine Uniform, Camo Conforming", floor(scale * 15), /obj/item/clothing/under/marine, VENDOR_ITEM_REGULAR),
 		list("Marine Uniform, Jungle BDU", floor(scale * 15), /obj/item/clothing/under/marine/standard, VENDOR_ITEM_REGULAR),
 		list("Marine Combat Gloves", floor(scale * 15), /obj/item/clothing/gloves/marine, VENDOR_ITEM_REGULAR),
@@ -222,7 +222,7 @@
 /obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep/upp/populate_product_list(scale)
 	listed_products = list(
 		list("STANDARD EQUIPMENT", -1, null, null, null),
-		list("Military Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine/upp, VENDOR_ITEM_REGULAR),
+		list("Military Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine/upp/knifeless, VENDOR_ITEM_REGULAR),
 		list("Naval Infantry Uniform", round(scale * 15), /obj/item/clothing/under/marine/veteran/UPP, VENDOR_ITEM_REGULAR),
 		list("Combat Gloves", round(scale * 15), /obj/item/clothing/gloves/marine, VENDOR_ITEM_REGULAR),
 		list("6b82 Combat Helmet (Green)", round(scale * 15), /obj/item/clothing/head/helmet/upp, VENDOR_ITEM_REGULAR),
@@ -296,7 +296,7 @@
 /obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep/pmc/populate_product_list(scale)
 	listed_products = list(
 		list("STANDARD EQUIPMENT", -1, null, null, null),
-		list("Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine/civilian/knife, VENDOR_ITEM_REGULAR),
+		list("Combat Boots", round(scale * 15), /obj/item/clothing/shoes/marine/civilian, VENDOR_ITEM_REGULAR),
 		list("PMC Uniform", round(scale * 15), /obj/item/clothing/under/marine/veteran/pmc, VENDOR_ITEM_REGULAR),
 		list("Combat Gloves", round(scale * 15), /obj/item/clothing/gloves/marine, VENDOR_ITEM_REGULAR),
 		list("Tactical Helmet", round(scale * 15), /obj/item/clothing/head/helmet/marine/veteran/pmc, VENDOR_ITEM_REGULAR),
@@ -361,7 +361,7 @@
 /obj/structure/machinery/cm_vending/sorted/uniform_supply/squad_prep/forecon/populate_product_list(scale)
 	listed_products = list(
 		list("STANDARD EQUIPMENT", -1, null, null, null),
-		list("Marine Jungle Boots", floor(scale * 15), /obj/item/clothing/shoes/marine/jungle/knife, VENDOR_ITEM_REGULAR),
+		list("Marine Jungle Boots", floor(scale * 15), /obj/item/clothing/shoes/marine/jungle, VENDOR_ITEM_REGULAR),
 		list("Marine Uniform, Camo Conforming", floor(scale * 15), /obj/item/clothing/under/marine, VENDOR_ITEM_REGULAR),
 		list("Marine Uniform, Jungle BDU", floor(scale * 15), /obj/item/clothing/under/marine/standard, VENDOR_ITEM_REGULAR),
 		list("Marine Black Gloves", round(scale * 15), /obj/item/clothing/gloves/marine, VENDOR_ITEM_REGULAR),
@@ -664,7 +664,7 @@
 		list("Laser Designator", round(scale * 2), /obj/item/device/binoculars/range/designator/upp, VENDOR_ITEM_REGULAR),
 		list("Spare PDT/L Battle Buddy Kit", round(scale * 3), /obj/item/storage/box/pdt_kit/advanced, VENDOR_ITEM_REGULAR),
 		list("Rail Flashlight", round(scale * 5), /obj/item/attachable/flashlight, VENDOR_ITEM_REGULAR),
-		list("Type 80 Bayonet", round(scale * 5), /obj/item/attachable/bayonet/upp, null, VENDOR_ITEM_REGULAR),
+		list("Type 80 Bayonet", round(scale * 25), /obj/item/attachable/bayonet/upp, null, VENDOR_ITEM_REGULAR),
 		list("Type 83 Grenade Launcher", 3, /obj/item/attachable/attached_gun/grenade/type71, null, VENDOR_ITEM_REGULAR),
 
 		list("CLOTHING", -1, null, null),
@@ -735,7 +735,7 @@
 		list("Spare PDT/L Battle Buddy Kit", round(scale * 3), /obj/item/storage/box/pdt_kit/advanced, VENDOR_ITEM_REGULAR),
 		list("Rail Flashlight", round(scale * 5), /obj/item/attachable/flashlight, VENDOR_ITEM_REGULAR),
 		list("Two-point Sling", round(scale * 5), /obj/item/attachable/sling, VENDOR_ITEM_REGULAR),
-		list("M13 Fighting Knife", round(scale * 5), /obj/item/weapon/knife/marine, VENDOR_ITEM_REGULAR),
+		list("M13 Fighting Knife", round(scale * 25), /obj/item/weapon/knife/marine, VENDOR_ITEM_REGULAR),
 
 		list("CLOTHING", -1, null, null),
 		list("Poncho (green)", round(scale * 10), /obj/item/clothing/accessory/poncho/green, VENDOR_ITEM_REGULAR),

--- a/code/game/objects/structures/crates_lockers/closets/secure/marine_personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/marine_personal.dm
@@ -6,7 +6,7 @@
 	var/owner
 	var/has_cryo_gear = TRUE
 
-	var/job = "DO NOT USE!!!"
+	var/job = "DO NOT USE!!!" //why isn't this just null?? why not explain further??? why is it a string????
 	var/x_to_linked_spawn_turf
 	var/y_to_linked_spawn_turf
 	var/turf/linked_spawn_turf
@@ -36,7 +36,7 @@
 
 /obj/structure/closet/secure_closet/marine_personal/proc/spawn_gear()
 	new /obj/item/clothing/under/marine(src)
-	new /obj/item/clothing/shoes/marine/jungle/knife(src)
+	new /obj/item/clothing/shoes/marine/jungle(src)
 	new /obj/item/device/radio/headset/almayer/marine/solardevils(src)
 
 /obj/structure/closet/secure_closet/marine_personal/rifleman
@@ -63,12 +63,12 @@
 	new /obj/item/clothing/under/marine/officer/bridge(src)
 	new /obj/item/clothing/suit/storage/jacket/marine/service(src)
 	new /obj/item/clothing/suit/storage/jacket/marine/dress/officer/bomber(src)
-	new /obj/item/clothing/shoes/marine/jungle/knife(src)
+	new /obj/item/clothing/shoes/marine/jungle(src)
 	new /obj/item/device/radio/headset/almayer/marine/solardevils(src)
 
 /obj/structure/closet/secure_closet/marine_personal/upp/spawn_gear()
 	new /obj/item/clothing/under/marine/veteran/UPP(src)
-	new /obj/item/clothing/shoes/marine/upp(src)
+	new /obj/item/clothing/shoes/marine/upp/knifeless(src)
 	new /obj/item/device/radio/headset/almayer/marine/solardevils/upp(src)
 
 /obj/structure/closet/secure_closet/marine_personal/upp/rifleman
@@ -92,14 +92,14 @@
 /obj/structure/closet/secure_closet/marine_personal/upp/platoon_commander/spawn_gear()
 	new /obj/item/clothing/under/marine/veteran/UPP/naval(src)
 	new /obj/item/clothing/suit/storage/jacket/marine/upp/naval(src)
-	new /obj/item/clothing/shoes/marine/upp(src)
+	new /obj/item/clothing/shoes/marine/upp/knifeless(src)
 	new /obj/item/device/radio/headset/almayer/marine/solardevils/upp(src)
 	new /obj/item/clothing/suit/storage/jacket/marine/upp/naval(src)
 	new /obj/item/clothing/suit/storage/jacket/marine/upp(src)
 
 /obj/structure/closet/secure_closet/marine_personal/forecon/spawn_gear()
 	new /obj/item/clothing/under/marine/standard(src)
-	new /obj/item/clothing/shoes/marine/jungle/knife(src)
+	new /obj/item/clothing/shoes/marine/jungle(src)
 	new /obj/item/device/radio/headset/almayer/marine/solardevils/forecon(src)
 
 /obj/structure/closet/secure_closet/marine_personal/forecon/rifleman
@@ -124,7 +124,7 @@
 /obj/structure/closet/secure_closet/marine_personal/pmc/spawn_gear()
 	new /obj/item/clothing/under/marine/veteran/pmc(src)
 	new /obj/item/device/radio/headset/distress/pmc/platoon(src)
-	new /obj/item/clothing/shoes/marine/civilian/knife(src)
+	new /obj/item/clothing/shoes/marine/civilian(src)
 
 /obj/structure/closet/secure_closet/marine_personal/pmc/rifleman
 	job = JOB_SQUAD_MARINE

--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -75,6 +75,9 @@
 /obj/item/clothing/shoes/marine/upp/guard/canc
 	spawn_item_type = /obj/item/weapon/knife/marine/chinese
 
+/obj/item/clothing/shoes/marine/upp/knifeless
+	spawn_item_type = null
+
 /obj/item/clothing/shoes/marine/pve_mopp
 	name = "\improper M2 MOPP boots"
 	desc = "M2 MOPP boots excel at keeping viscera or other biological contaminants away from your feet."


### PR DESCRIPTION
# About the pull request
Boots in lockers and vendors no longer have knives in them.
# Explain why it's good for the game
Honestly? I've seen enough people ask for it and it's simple enough that I kind of just want to see if it'll be merged. The main reason I'm for it instead of neutral is because taking my boot knife out to replace it with my loadout one and then stuff it back in my locker is a pain.
# Changelog

:cl:
del: Removes knives from boots in lockers and vendors.
/:cl: