### PR TITLE
Adds the MS-11 Smart Refill tank to the corpsmans chemical vendor

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_medic.dm
@@ -340,6 +340,9 @@ GLOBAL_LIST_INIT(cm_vending_chemical_medic, list(
 		list("Liquid Bottle (Meralyne-Bicardine)", 40, /obj/item/reagent_container/glass/bottle/merabica, null, VENDOR_ITEM_REGULAR),
 		list("Liquid Bottle (Kelotane-Dermaline)", 40, /obj/item/reagent_container/glass/bottle/keloderm, null, VENDOR_ITEM_REGULAR),
 		list("Liquid Bottle (Dexalin+)", 40, /obj/item/reagent_container/glass/bottle/dexalinplus, null, VENDOR_ITEM_REGULAR),
+
+		list("INJECTORS", 0, null, null, null),
+		list("Smart Refill Tank)", 40, /obj/item/reagent_container/glass/minitank, null, VENDOR_ITEM_REGULAR),
 	))
 
 /obj/structure/machinery/cm_vending/gear/medic_chemical

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -244,7 +244,7 @@
 	matter = list("metal" = 500)
 	attack_speed = 4
 	volume = 180
-	w_class = SIZE_MEDIUM
+	w_class = SIZE_SMALL
 	splashable = FALSE
 	can_be_placed_into = list(
 		/obj/structure/machinery/chem_master/,


### PR DESCRIPTION

Adds the ms-11 smart refill tank to corpsmans chemical vendor 


# Explain why it's good for the game
Auto-injector builds are both cool and soul, however they require a lot of space commitment to achieve the same results as pill bottles.  The tank can be filled with chemical bottles and used to refill auto-injectors of that type. Corpsmen could use it as a storage option for chemicals like oxy and tricord or hand it out to refill the marines injectors on operations with no medstations



# Changelog

:cl:
add:  The USCM has allowed the limited Issue of MS-11 smart refill tanks
/:cl:
