### PR TITLE
Adds USASF Infantry roles & HAI Squad presets

### DIFF
--- a/code/modules/gear_presets/usasf.dm
+++ b/code/modules/gear_presets/usasf.dm
@@ -82,6 +82,86 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full(new_human), WEAR_L_STORE)
 	..()
 
+/datum/equipment_preset/usasf/crew/armsman/armed
+	name = "USASF Master-At-Arms (Armed, Rifle)"
+	role_comm_title = "MAA"
+	paygrades = list(PAY_SHORT_NE5 = JOB_PLAYTIME_TIER_0)
+	flags = EQUIPMENT_PRESET_EXTRA
+
+/datum/equipment_preset/usasf/crew/armsman/armed/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/engi(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/armband/mpsec(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/medium/rto/navy(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/MP(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41aMK1/(new_human), WEAR_J_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/marine/m41amk1(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/alt(new_human), WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/vp70(new_human), WEAR_IN_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full(new_human), WEAR_L_STORE)
+	..()
+
+/datum/equipment_preset/usasf/crew/armsman/armed_shotgun
+	name = "USASF Master-At-Arms (Armed, Shotgun)"
+	role_comm_title = "MAA"
+	paygrades = list(PAY_SHORT_NE5 = JOB_PLAYTIME_TIER_0)
+	flags = EQUIPMENT_PRESET_EXTRA
+
+/datum/equipment_preset/usasf/crew/armsman/armed_shotgun/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/engi(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/armband/mpsec(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/medium/rto/navy(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/MP(new_human), WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/gun/xm51(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/xm51/military(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/xm51(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/xm51(new_human), WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/alt(new_human), WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/vp70(new_human), WEAR_IN_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full(new_human), WEAR_L_STORE)
+	..()
+
+/datum/equipment_preset/usasf/crew/infantry
+	name = "USASF Aerospace Marine (Rifleman)"
+	assignment = "USASF Aerospace Marine Rifleman"
+	paygrades = list(PAY_SHORT_NE3 = JOB_PLAYTIME_TIER_0)
+	role_comm_title = "MAR"
+	flags = EQUIPMENT_PRESET_EXTRA
+	idtype = /obj/item/card/id/dogtag
+	skills = /datum/skills/pfc
+
+/datum/equipment_preset/usasf/crew/infantry/load_gear(mob/living/carbon/human/new_human)
+	new_human.equip_to_slot_or_del(new headset_type, WEAR_L_EAR)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/satchel(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/box/mre(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/weldingtool(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/wirecutters(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/shovel/etool/folded(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/crowbar/tactical(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/food/drinks/flask/canteen, WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/engi(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch/usasf(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/holster/waist(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/vp70, WEAR_IN_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/medium/rto/navy(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/webbing/m3/recon/mk1(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41aMK1/navy(new_human), WEAR_J_STORE)
+	var/random_usasf_infantry_helmet = rand(1,3)
+	switch(random_usasf_infantry_helmet)
+		if(1 to 2)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/rto/navy, WEAR_HEAD)
+		if(3)
+			new_human.equip_to_slot_or_del(new /obj/item/clothing/head/cmcap/corrections, WEAR_HEAD)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/marine/m41amk1(new_human), WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine(new_human), WEAR_HANDS)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/army/knife(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full/alternate(new_human), WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/flare/full(new_human), WEAR_R_STORE)
+
+/datum/equipment_preset/usasf/crew/infantry/nco
+	name = parent_type::name + " (Team Lead)"
+	paygrades = list(PAY_SHORT_NE4 = JOB_PLAYTIME_TIER_0)
+	assignment = "USASF Aerospace Marine Team Leader"
+
 /datum/equipment_preset/usasf/crew/flight
 	name = "USASF Flight-Deck Crewman"
 	assignment = JOB_NAVY_SKITTLE
@@ -179,6 +259,29 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/army/knife(new_human), WEAR_FEET)
 //Back
 	new_human.equip_to_slot_or_del(new /obj/item/parachute(new_human), WEAR_BACK)
+
+/datum/equipment_preset/usasf/helljumper/squadlead
+	name = "USASF Para-Rescue Support Technician (Squad Leader)"
+	paygrades = list(PAY_SHORT_NE9 = JOB_PLAYTIME_TIER_0)
+	assignment = "USASF Para-Rescue Support Squad Lead"
+	role_comm_title = "PJ-SL"
+	flags = EQUIPMENT_PRESET_EXTRA
+
+/datum/equipment_preset/usasf/helljumper/squadlead/load_gear(mob/living/carbon/human/new_human)
+
+//Uniform & accessories
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine/officer/pilot/flight/para(new_human), WEAR_BODY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch/usasf(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/patch/usasf/helljumper(new_human), WEAR_ACCESSORY)
+//Armor, webbing & weapon
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/medium/rto/navy(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/webbing/m3/recon/mk1(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/m41aMK1/navy(new_human), WEAR_J_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/belt/marine/m41amk1(new_human), WEAR_WAIST)
+//Role specific
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/tools/tactical/parajumper(new_human), WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/medical/socmed/not_op(new_human), WEAR_L_STORE)
+	..()
 
 /datum/equipment_preset/usasf/helljumper/technical
 	name = "USASF Para-Rescue Support Technician (Engineering)"

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_army.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_army.dm
@@ -68,3 +68,38 @@
 		/datum/equipment_preset/usa/snco = 1,
 		/datum/equipment_preset/usa/trooper = 2,
 	)
+
+/datum/human_ai_squad_preset/army/usasf
+	name = "USASF Patrol Team"
+	desc = "A US Aerospace Force Marine patrol team of 2 riflemen and 1 squad leader."
+	ai_to_spawn = list(
+		/datum/equipment_preset/usasf/crew/infantry/nco = 1,
+		/datum/equipment_preset/usasf/crew/infantry = 2,
+	)
+
+/datum/human_ai_squad_preset/army/usasf/maa
+	name = "USASF Master-At-Arms Squad"
+	desc = "A US Aerospace Force armed Master-At-Arms Squad. Specialized in close-quarters-environment in spaceships. Comes with 2 shotgunners and 1 rifleman."
+	ai_to_spawn = list(
+		/datum/equipment_preset/usasf/crew/armsman/armed = 1,
+		/datum/equipment_preset/usasf/crew/armsman/armed_shotgun = 2,
+	)
+
+/datum/human_ai_squad_preset/army/usasf/helljumper
+	name = "USASF Para-Rescue Squad"
+	desc = "A US Aerospace Force Para-Rescue Jumper ('PJs' or 'Helljumpers') Squad. A special unit which conducts operations deep behind hostile lines to support injured or stranded personnel. Comes with 1 Squad leader, 2 Technicians and 1 Corpsman."
+	ai_to_spawn = list(
+		/datum/equipment_preset/usasf/helljumper/squadlead = 1,
+		/datum/equipment_preset/usasf/helljumper/technical = 2,
+		/datum/equipment_preset/usasf/helljumper/medical = 1,
+	)
+
+/datum/human_ai_squad_preset/army/usasf/jtac
+	name = "USASF JTAC Team"
+	desc = "A US Aerospace Force infantry Squad which provides Forward Air Control, spotting enemy positions for Close Air Support and Orbital bombardment. Composed by 1 officer, 1 aide and 2 escorts."
+	ai_to_spawn = list(
+		/datum/equipment_preset/usasf/jtac = 1,
+		/datum/equipment_preset/usasf/jtac/lesser_rank = 1,
+		/datum/equipment_preset/usasf/crew/infantry/nco = 1,
+		/datum/equipment_preset/usasf/crew/infantry = 1,
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

This PR adds a couple of USASF Infantry presets. In addition, some USASF HAI Squad presets were added under the US Army tab (since it's only a couple of them, I didn't see the use of adding a new tab just for USASF). 

New Presets
* Armed Master-At-Mars: Using the MAA as a base, but now wearing armor, helmet and a deadly weapon. One is a rifleman and the other a shotgunner.
* Aerospace Marine: Not very satisfied with this name, I also thought "Aerospace Infantry" and "Aerospace Security" if it's too confusing. Basically a USCM Rifleman with a USASF skin. There's also an extra NCO variant so a full squad can be formed.
* Para-Rescue Squad Leader: So a full PJ Squad can be formed. The PJ SL has stuff from both Engineer tech and Medical tech, so they can support either elements.

HAI Squads:
* USASF Patrol: A small team with 3 Aerospace Marines
* USASF Master-At-Arms Squad: 3 Armed Master-At-Arms. 2 shotgunners and 1 rifleman
* USASF Para-Rescue Squad: 1 PJ-SL, 2 PJ Techs and 1 PJ Medic
* USASF JTAC Squad: 1 Officer RTO, 1 NCO RTO, 1 Aerospace Marine NCO and 1 Aerospace Marine 

# Explain why it's good for the game

The idea came to me when I wanted to use some combat roles in a joint USASF-USCM op and there weren't presets that satisfied me, as such extra combat/infantry roles may help GMs fit the USASF in their ops. The new HAI Squads also help GMs to spawn them faster.

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<img width="630" height="578" alt="Captura de tela 2025-07-15 212256" src="https://github.com/user-attachments/assets/83cb8e9f-58b1-4a4e-8f50-44754fb88595" />
<img width="201" height="250" alt="Captura de tela 2025-07-15 211318" src="https://github.com/user-attachments/assets/154ca0e9-54a7-4d1a-aa1d-11416323312c" />


</details>


# Changelog


:cl:
add: New USASF Infantry Presets and Human AI squads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
