### PR TITLE
Operations Caps to the Loadout and Squad Prep Vendors

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -106,9 +106,10 @@
 		list("Marine Combat Gloves", floor(scale * 15), /obj/item/clothing/gloves/marine, VENDOR_ITEM_REGULAR),
 		list("Marine Radio Headset", floor(scale * 15), /obj/item/device/radio/headset/almayer/marine/solardevils, VENDOR_ITEM_REGULAR),
 		list("M5 Pattern Camera Headset", floor(scale * 15), /obj/item/device/overwatch_camera, VENDOR_ITEM_REGULAR),
-		list("Patrol Cap, Jungle", floor(scale * 15), /obj/item/clothing/head/cmcap, VENDOR_ITEM_REGULAR),
-		list("Patrol Cap, Snow", floor(scale * 15), /obj/item/clothing/head/cmcap/snow, VENDOR_ITEM_REGULAR),
-		list("Patrol Cap, Desert", floor(scale * 15), /obj/item/clothing/head/cmcap/desert, VENDOR_ITEM_REGULAR),
+		list("Utility Cap, Jungle", floor(scale * 15), /obj/item/clothing/head/cmcap, VENDOR_ITEM_REGULAR),
+		list("Utility Cap, Snow", floor(scale * 15), /obj/item/clothing/head/cmcap/snow, VENDOR_ITEM_REGULAR),
+		list("Utility Cap, Desert", floor(scale * 15), /obj/item/clothing/head/cmcap/desert, VENDOR_ITEM_REGULAR),
+		list("Operations Cap", floor(scale * 15), /obj/item/clothing/head/cmcap/bridge, VENDOR_ITEM_REGULAR),
 		list("Boonie Hat, Jungle", floor(scale * 15), /obj/item/clothing/head/cmcap/boonie, VENDOR_ITEM_REGULAR),
 		list("Boonie Hat, Desert", floor(scale * 15), /obj/item/clothing/head/cmcap/boonie/tan, VENDOR_ITEM_REGULAR),
 

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -109,7 +109,8 @@
 		list("Utility Cap, Jungle", floor(scale * 15), /obj/item/clothing/head/cmcap, VENDOR_ITEM_REGULAR),
 		list("Utility Cap, Snow", floor(scale * 15), /obj/item/clothing/head/cmcap/snow, VENDOR_ITEM_REGULAR),
 		list("Utility Cap, Desert", floor(scale * 15), /obj/item/clothing/head/cmcap/desert, VENDOR_ITEM_REGULAR),
-		list("Operations Cap", floor(scale * 15), /obj/item/clothing/head/cmcap/bridge, VENDOR_ITEM_REGULAR),
+		list("Operations Cap, Green", floor(scale * 15), /obj/item/clothing/head/cmcap/bridge, VENDOR_ITEM_REGULAR),
+		list("Operations Cap, Tan", floor(scale * 15), /obj/item/clothing/head/cmcap/khaki, VENDOR_ITEM_REGULAR),
 		list("Boonie Hat, Jungle", floor(scale * 15), /obj/item/clothing/head/cmcap/boonie, VENDOR_ITEM_REGULAR),
 		list("Boonie Hat, Desert", floor(scale * 15), /obj/item/clothing/head/cmcap/boonie/tan, VENDOR_ITEM_REGULAR),
 

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -315,7 +315,7 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 
 /datum/gear/headwear/uscm/cap_desert
 	display_name = "USCM cap, desert"
-	path = /obj/item/clothing/head/cmcap/khaki
+	path = /obj/item/clothing/head/cmcap/desert
 	cost = 2
 
 /datum/gear/headwear/uscm/cap_snow

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -311,18 +311,25 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 /datum/gear/headwear/uscm/cap
 	display_name = "USCM cap, jungle"
 	path = /obj/item/clothing/head/cmcap
+	cost = 2
 
 /datum/gear/headwear/uscm/cap_desert
 	display_name = "USCM cap, desert"
 	path = /obj/item/clothing/head/cmcap/khaki
+	cost = 2
 
 /datum/gear/headwear/uscm/cap_snow
 	display_name = "USCM cap, snow"
 	path = /obj/item/clothing/head/cmcap/snow
+	cost = 2
 
 /datum/gear/headwear/uscm/cap_operations
-	display_name = "USCM Operations Cap"
+	display_name = "USCM Operations Cap, Green"
 	path = /obj/item/clothing/head/cmcap/bridge
+
+/datum/gear/headwear/uscm/cap_operations2
+	display_name = "USCM Operations Cap, Tan"
+	path = /obj/item/clothing/head/cmcap/khaki
 
 /datum/gear/headwear/uscm/cap/sulaco
 	display_name = "USS Golden Arrow cap"

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -320,6 +320,10 @@ GLOBAL_LIST_EMPTY(gear_datums_by_name)
 	display_name = "USCM cap, snow"
 	path = /obj/item/clothing/head/cmcap/snow
 
+/datum/gear/headwear/uscm/cap_operations
+	display_name = "USCM Operations Cap"
+	path = /obj/item/clothing/head/cmcap/bridge
+
 /datum/gear/headwear/uscm/cap/sulaco
 	display_name = "USS Golden Arrow cap"
 	path = /obj/item/clothing/head/sulacocap

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -207,8 +207,8 @@
 	)
 
 /obj/item/clothing/head/cmcap
-	name = "patrol cap"
-	desc = "A patrol cap issued as part of the non-combat uniform. While it only protects from the sun, it's much more comfortable than a helmet."
+	name = "utility cap"
+	desc = "A utility cap issued as part of the non-combat uniform. While it only protects from the sun, it's much more comfortable than a helmet."
 	icon_state = "cap"
 	icon = 'icons/obj/items/clothing/cm_hats.dmi'
 	flags_atom = FPRINT|NO_SNOW_TYPE
@@ -388,18 +388,18 @@
 	icon_state = "cap_khaki"
 
 /obj/item/clothing/head/cmcap/snow
-	name = "\improper coldweather patrol cap"
-	desc = "A patrol cap worn in cold weather environments."
+	name = "\improper coldweather utility cap"
+	desc = "A utility cap worn in cold weather environments."
 	icon_state = "cap_snow"
 
 /obj/item/clothing/head/cmcap/desert
-	name = "\improper desert patrol cap"
-	desc = "A desert BDU patrol cap."
+	name = "\improper desert utility cap"
+	desc = "A desert BDU utility cap."
 	icon_state = "cap_desert"
 
 /obj/item/clothing/head/cmcap/bridge
 	name = "\improper USCM operations cap"
-	desc = "A hat usually worn by officers in the USCM. While it provides no protection, some officers wear it in the field to make themselves more recognisable."
+	desc = "A thicker headcover designed by the Colonial Marines to withstand the elements better out in the field or while performing maintenance. Thicker materials and colored in OD green, the letters 'USCM' are boldy placed in black letters on the front."
 	icon_state = "cap_operations"
 
 /obj/item/clothing/head/cmcap/flap

--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -383,8 +383,8 @@
 	icon_state = "co_formalhat_black"
 
 /obj/item/clothing/head/cmcap/khaki
-	name = "\improper khaki patrol cap"
-	desc = "A khaki patrol cap."
+	name = "\improper khaki USCM operations cap"
+	desc = "A thicker headcover designed by the Colonial Marines to withstand the elements better out in the field or while performing maintenance. Thicker materials and colored in desert tan, the letters 'USCM' are boldy placed in black letters on the front."
 	icon_state = "cap_khaki"
 
 /obj/item/clothing/head/cmcap/snow
@@ -398,7 +398,7 @@
 	icon_state = "cap_desert"
 
 /obj/item/clothing/head/cmcap/bridge
-	name = "\improper USCM operations cap"
+	name = "\improper green USCM operations cap"
 	desc = "A thicker headcover designed by the Colonial Marines to withstand the elements better out in the field or while performing maintenance. Thicker materials and colored in OD green, the letters 'USCM' are boldy placed in black letters on the front."
 	icon_state = "cap_operations"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Changes the patrol caps to be named 'utility caps' rather than patrol, to match their description. The operations cap has also been adjusted to not be strictly an 'officer' cap and is also now in the loadout store and prep vendor as an option for all Marines. The khaki cap is now more stand out than the desert cap, being the desert opposite to the green operations cap.

# Explain why it's good for the game
The operations cap wasn't just something Gorman wore, as Private Drake also wore the cap in the movie both forwards and backwards (A:CM mistakes it to be a black cap because of the lighting of Hadley's Hope) so making it available is just more options for players. Since the patrol caps also existed, I adjusted them to be 'noncombat' to complete the look of the BDU and dropped their price. The khaki and green operations caps also tone match the armor, making them look more appropriate in the field.

# Testing Photographs and Procedure
N/A

# Changelog

:cl:
add: 2 Operations cap entries into the preference screen, one for green and the other for tan
add: 2 Operations cap entries into the squad prep machinery, ditto
add: Old patrol caps now properly are referenced as 'utility' caps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
