### PR TITLE
Smartguns Come Unloaded

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -123,10 +123,11 @@
 
 /obj/structure/closet/secure_closet/smartgunner/Initialize()
 	. = ..()
-	new /obj/item/weapon/gun/smartgun(src)
+	new /obj/item/weapon/gun/smartgun/empty(src)
 	new /obj/item/smartgun_battery(src)
 	new /obj/item/clothing/suit/marine/smartgunner(src)
 	new /obj/item/storage/belt/gun/smartgunner/garrow(src)
+	new /obj/item/ammo_magazine/smartgun(src)
 	new /obj/item/ammo_magazine/smartgun(src)
 	new /obj/item/ammo_magazine/smartgun(src)
 	new /obj/item/clothing/glasses/night/m56_goggles/no_nightvision(src)

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -598,6 +598,10 @@
 		if(!auto_fire)
 			STOP_PROCESSING(SSobj, src)
 */
+
+/obj/item/weapon/gun/smartgun/empty
+	current_mag = null
+
 //CO SMARTGUN
 /obj/item/weapon/gun/smartgun/co
 	name = "\improper M56C 'Cavalier' smartgun"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
Smartguns no longer come preloaded and instead smartgunners will have to manually load their guns. An extra drum has been added to the lockers as compensation.

# Explain why it's good for the game
No longer will smartgunners be able to look down on the rest of the section like peons for not getting their own weapons preloaded.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>
Hi

</details>


# Changelog

:cl:
add: Added extra ammo dum to Smartgun Lockers
del: Removed ammo drum from the stored smartguns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
