### PR TITLE
Player Origins fix

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -716,6 +716,7 @@
 	undershirt = sanitize_inlist(undershirt, gender == MALE ? GLOB.undershirt_m : GLOB.undershirt_f, initial(undershirt))
 	backbag = sanitize_integer(backbag, 1, length(GLOB.backbaglist), initial(backbag))
 	preferred_armor = sanitize_inlist(preferred_armor, GLOB.armor_style_list, "Random")
+	origin = sanitize_inlist(origin, FACTION_ORIGINS, ORIGIN_USCM)
 	//b_type = sanitize_text(b_type, initial(b_type))
 
 	platoon_name = platoon_name ? sanitize_text(platoon_name, initial(platoon_name)) : "Sun Riders"


### PR DESCRIPTION
# About the pull request

Adds a sanitisation check for the origins so players aren't stuck with old (no longer loadout-eligable) United Americas origins

# Explain why it's good for the game

Less jank = gooder

# Testing Photographs and Procedure
Tested locally using an older branch to create several new characters with various UA origins before swapping to this and checking that the older ones were sanitised. They were.

# Changelog

:cl:
fix: Old origins shouldn't linger and prevent eligability for UA loadout things
code: Adds a sanitisation check for the origins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
