### PR TITLE
[KEEP TM'D] Prevents ghosts from interacting with player inventories

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -294,6 +294,9 @@
 /atom/movable/screen/inventory/proc/handle_dropped_on(atom/dropped_on, atom/dropping, client/user)
 	SIGNAL_HANDLER
 
+	if(!isliving(user.mob))
+		return
+
 	if(slot_id != WEAR_L_HAND && slot_id != WEAR_R_HAND)
 		return
 


### PR DESCRIPTION
# About the pull request

Ports [#11421](https://github.com/cmss13-devs/cmss13/pull/11421)
Stops ghost from being able to mess with player inventories

# Changelog

🆑 MistChristmas
fix: Ghosts no longer able to move items out of open inventories when orbiting
/:cl: