### PR TITLE
FSM - Flyby/Hover with SFX (also in Various fixes & tweaks PR)

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -218,6 +218,10 @@
 	icon = 'icons/obj/items/weapons/projectiles.dmi'
 	icon_state = "laser_target3"
 
+/obj/effect/overlay/temp/blinking_laser/invis
+	light_range = 0
+	effect_duration = 1
+
 /obj/effect/overlay/temp/plasma_impact
 	name = "plasma impact"
 	icon = 'icons/effects/effects.dmi'

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -221,6 +221,7 @@
 /obj/effect/overlay/temp/blinking_laser/invis
 	light_range = 0
 	effect_duration = 1
+	invisibility = INVISIBILITY_LEVEL_ONE
 
 /obj/effect/overlay/temp/plasma_impact
 	name = "plasma impact"

--- a/code/modules/admin/game_master/extra_buttons/fire_support_menu.dm
+++ b/code/modules/admin/game_master/extra_buttons/fire_support_menu.dm
@@ -8,6 +8,7 @@
 #define CHEMICAL_ORDNANCE list("CN-20 Missile", "Nerve Gas OB", "Nerve Gas Shell")
 #define MISC_ORDNANCE list("Laser", "Minirocket", "Incendiary Minirocket",  "Sentry Drop", "25mm Multipurpose Strike", "25mm Armorpiercing Strike")
 #define THROWABLES_ORDNANCE list("HE", "HE - UPP", "HE - RMC", "Frag", "Incendiary", "Molotov", "Incendiary - RMC", "Smoke - White", "Smoke - Green", "Smoke - Red", "Smoke - UPP", "WP", "WP - UPP", "Ball-Breakers", "Nerve Gas", "LSD", "Tear Gas", "Metal Foam", "Flare", "Flare - UPP", "Flare - Signal")
+#define FLYBY_ORDNANCE list("Cheyenne Flyby", "Cheyenne Hover", "Krokodil Flyby", "Krokodil Hover")
 
 /client/proc/toggle_fire_support_menu()
 	set name = "Fire Support Menu"
@@ -24,6 +25,10 @@
 	///Mortar to fire the abstract shells.
 	var/obj/structure/mortar/abstract_mortar = new()
 	var/client/holder
+	//flyby stuff
+	var/flyby_effect = /obj/effect/temp_visual/dropship_flyby
+	var/flyby_sound = 'sound/weapons/dropship_sonic_boom.ogg'
+	var/flyby_cooldown = FALSE
 
 /datum/fire_support_menu/New(user)
 	if(isclient(user))
@@ -60,6 +65,7 @@
 	data["chemical_ordnance_options"] = CHEMICAL_ORDNANCE
 	data["misc_ordnance_options"] = MISC_ORDNANCE
 	data["throwables_ordnance_options"] = THROWABLES_ORDNANCE
+	data["flyby_ordnance_options"] = FLYBY_ORDNANCE
 
 	return data
 
@@ -433,6 +439,51 @@
 
 				return TRUE
 
+			//Flyby Effects (no actual ordnance, just the visual and sound effects of a dropship flying over or hovering)
+			if("Cheyenne Flyby")
+				var/obj/effect/overlay/temp/blinking_laser/invis/target_lase = new(target_turf)
+				flyby_effect = /obj/effect/temp_visual/dropship_flyby
+				flyby_sound = 'sound/weapons/dropship_sonic_boom.ogg'
+
+				handle_flyby_initiate(target_turf)
+
+				QDEL_IN(target_lase, 1 SECONDS)  //to stop "unused var" warnings
+
+				return TRUE
+
+			if("Cheyenne Hover")
+				var/obj/effect/overlay/temp/blinking_laser/invis/target_lase = new(target_turf)
+				flyby_effect = /obj/effect/temp_visual/dropship_hover
+				flyby_sound = 'sound/weapons/fire_support/dropship_hover.ogg'
+
+				handle_flyby_initiate(target_turf)
+
+				QDEL_IN(target_lase, 1 SECONDS)  //to stop "unused var" warnings
+
+				return TRUE
+
+			if("Krokodil Flyby")
+				var/obj/effect/overlay/temp/blinking_laser/invis/target_lase = new(target_turf)
+				flyby_effect = /obj/effect/temp_visual/dropship_flyby/krokodil
+				flyby_sound = 'sound/weapons/dropship_sonic_boom.ogg'
+
+				handle_flyby_initiate(target_turf)
+
+				QDEL_IN(target_lase, 1 SECONDS)  //to stop "unused var" warnings
+
+				return TRUE
+
+			if("Krokodil Hover")
+				var/obj/effect/overlay/temp/blinking_laser/invis/target_lase = new(target_turf)
+				flyby_effect = /obj/effect/temp_visual/dropship_hover/krokodil
+				flyby_sound = 'sound/weapons/fire_support/dropship_hover.ogg'
+
+				handle_flyby_initiate(target_turf)
+
+				QDEL_IN(target_lase, 1 SECONDS)  //to stop "unused var" warnings
+
+				return TRUE
+
 			else
 				to_chat(user, SPAN_ANNOUNCEMENT_HEADER_ADMIN("Invalid ordnance selection! If this appears, yell at a coder!"))
 				return TRUE
@@ -442,6 +493,17 @@
 	if(!sound_cooldown)
 		playsound(target_turf, 'sound/weapons/dropship_sonic_boom.ogg', 100, 1, 60)
 		sound_cooldown = TRUE
+		addtimer(VARSET_CALLBACK(src, sound_cooldown, FALSE), 10 SECONDS)
+
+/datum/fire_support_menu/proc/handle_flyby_initiate(turf/target_turf)
+	if(!flyby_cooldown)
+		if(flyby_effect)
+			new flyby_effect(target_turf)
+		if(flyby_sound)
+			playsound(target_turf, flyby_sound, 100, 1, 60)
+		sound_cooldown = TRUE
+		flyby_cooldown = TRUE
+		addtimer(VARSET_CALLBACK(src, flyby_cooldown, FALSE), 10 SECONDS)
 		addtimer(VARSET_CALLBACK(src, sound_cooldown, FALSE), 10 SECONDS)
 
 ///Handles the noises and actual detonation of dropship ammo. Mainly it doesnt play the warning sound for ammo of the ship_ammo/heavygun/ type.
@@ -461,4 +523,5 @@
 #undef MISC_ORDNANCE
 #undef CHEMICAL_ORDNANCE
 #undef THROWABLES_ORDNANCE
+#undef FLYBY_ORDNANCE
 #undef FIRE_SUPPORT_CLICK_INTERCEPT_ACTION

--- a/tgui/packages/tgui/interfaces/GameMasterFireSupportMenu.jsx
+++ b/tgui/packages/tgui/interfaces/GameMasterFireSupportMenu.jsx
@@ -121,6 +121,21 @@ export const GameMasterFireSupportMenu = (props, context) => {
               </Button>
             ))}
           </Collapsible>
+
+          <Collapsible content="Flyby Ordnance">
+            {data.flyby_ordnance_options.map((ordnance, i) => (
+              <Button
+                selected={data.selected_ordnance === ordnance}
+                key={i}
+                width={'100px'}
+                onClick={() => {
+                  act('set_selected_ordnance', { ordnance });
+                }}
+              >
+                {ordnance}
+              </Button>
+            ))}
+          </Collapsible>
         </Section>
       </Window.Content>
     </Window>


### PR DESCRIPTION

# About the pull request

I saw that GMs were spawning the flyby effects, but just the effect itself has no sound which is not ideal. As such I added some buttons to the GM Fire Support Menu to spawn the flyby and hover effects _including_ their associated sound effects.

I also added a new laser to facilitate this rather than it being the standard 5s blinker. Ghosts/GM can see it for a second but players can't

Pandora added this to #1218 so that they would merge together

# Explain why it's good for the game

Just makes it easier for GMs to signal to players "hey btw there is air support in your vicinity"


# Testing Photographs and Procedure
tested locally

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: Flyby / Hover procs in Fire Support & a laser overlay for em
ui: Specific buttons to proc the flyby/hover effects in Fire Support Menu
/:cl:

