### PR TITLE
CANC presets & squad spawner tweak

### DIFF
--- a/code/modules/gear_presets/canc.dm
+++ b/code/modules/gear_presets/canc.dm
@@ -30,11 +30,14 @@
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
 	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
 	//uniform
@@ -72,12 +75,14 @@
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
 	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
-	//head
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
 	//uniform
 	add_canc_uniform(new_human)
@@ -113,11 +118,14 @@
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
 	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	//head
 	if(prob(50))
 		var/coolhat = pick(/obj/item/clothing/head/headband/red, /obj/item/clothing/head/cmcap/flap/canc, /obj/item/clothing/head/uppcap/boonie/canc)
@@ -158,11 +166,14 @@
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
 	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
 	//uniform
@@ -197,11 +208,14 @@
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
 	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
 	//uniform
@@ -238,11 +252,14 @@
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
 	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
 	//uniform
@@ -291,14 +308,15 @@
 		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/prescription, WEAR_EYES)
 	else
 		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health, WEAR_EYES)
+	var/random_neckwear_canc = rand(1,4)
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
 		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
-	var/random_neckwear_canc = rand(1,4)
-	switch(random_neckwear_canc)
-		if(1,2)
-			add_neckerchief(new_human)
-		if(3)
-			add_facewrap(new_human)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
 	//head
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
 	//uniform
@@ -338,6 +356,8 @@
 	add_random_satchel(new_human)
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
 	//uniform
 	add_civilian_uniform(new_human)
 	//jacket
@@ -376,6 +396,8 @@
 	add_random_satchel(new_human)
 	//face
 	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
 	//uniform
 	add_civilian_uniform(new_human)
 	//jacket

--- a/code/modules/gear_presets/canc.dm
+++ b/code/modules/gear_presets/canc.dm
@@ -59,11 +59,56 @@
 /datum/equipment_preset/canc/remnant/leader
 	name = "CANC Rebel, Unit Leader"
 	flags = EQUIPMENT_PRESET_EXTRA
-	paygrades = list(PAY_SHORT_CA5 = JOB_PLAYTIME_TIER_0)
+	paygrades = list(PAY_SHORT_CA4 = JOB_PLAYTIME_TIER_0)
 	assignment = "Unit Leader"
 	skills = /datum/skills/tl
 
 /datum/equipment_preset/canc/remnant/leader/load_gear(mob/living/carbon/human/new_human)
+	new_human.undershirt = "undershirt"
+	//back
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack/upp(new_human), WEAR_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/roller/bedroll(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/box/mre/upp(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/tool/kitchen/can_opener(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/reagent_container/food/drinks/flask/canteen(new_human), WEAR_IN_BACK)
+	new_human.equip_to_slot_or_del(new /obj/item/device/binoculars/range(new_human), WEAR_IN_BACK)
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
+	var/random_neckwear_canc = rand(1,4)
+	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/mask/rebreather/scarf, WEAR_FACE)
+	else
+		switch(random_neckwear_canc)
+			if(1,2)
+				add_neckerchief(new_human)
+			if(3)
+				add_facewrap(new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
+	//uniform
+	add_canc_uniform(new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e4(new_human), WEAR_ACCESSORY)
+	//jacket
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/faction/UPP/CANC(new_human), WEAR_JACKET)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/upp/guard/canc(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/brown(new_human), WEAR_HANDS)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full/alternate(new_human), WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/alt, WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/t73, WEAR_IN_R_STORE)
+	add_canc_rifle(new_human)
+	if(prob(30))
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/mgoggles/orange(new_human), WEAR_IN_HELMET)
+
+/datum/equipment_preset/canc/remnant/officer
+	name = "CANC Rebel, Officer"
+	flags = EQUIPMENT_PRESET_EXTRA
+	paygrades = list(PAY_SHORT_CA5 = JOB_PLAYTIME_TIER_0)
+	assignment = "Officer"
+	skills = /datum/skills/lt
+
+/datum/equipment_preset/canc/remnant/officer/load_gear(mob/living/carbon/human/new_human)
 	new_human.undershirt = "undershirt"
 	//back
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/lightpack/upp(new_human), WEAR_BACK)
@@ -104,7 +149,7 @@
 /datum/equipment_preset/canc/remnant/marksman
 	name = "CANC Rebel, Marksman"
 	flags = EQUIPMENT_PRESET_EXTRA
-	paygrades = list(PAY_SHORT_CA2 = JOB_PLAYTIME_TIER_0)
+	paygrades = list(PAY_SHORT_CA3 = JOB_PLAYTIME_TIER_0)
 	assignment = "Marksman"
 
 /datum/equipment_preset/canc/remnant/marksman/load_gear(mob/living/carbon/human/new_human)
@@ -138,7 +183,7 @@
 	//uniform
 	add_canc_uniform(new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e2(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e3(new_human), WEAR_ACCESSORY)
 	//jacket
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/faction/UPP/CANC(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/rifle/lw317/dmr(new_human), WEAR_J_STORE)
@@ -157,6 +202,7 @@
 /datum/equipment_preset/canc/machinegunner
 	name = "CANC Rebel, Machinegunner"
 	flags = EQUIPMENT_PRESET_EXTRA
+	paygrades = list(PAY_SHORT_CA2 = JOB_PLAYTIME_TIER_0)
 	assignment = "Machinegunner"
 	skills = /datum/skills/smartgunner
 	access = list(ACCESS_UPP_GENERAL, ACCESS_UPP_MACHINEGUN)
@@ -179,7 +225,7 @@
 	//uniform
 	add_canc_uniform(new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e1(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e2(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/general_belt/upp, WEAR_WAIST)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp/standard_fmj, WEAR_IN_BELT)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp/standard_fmj, WEAR_IN_BELT)
@@ -200,6 +246,7 @@
 	name = "CANC Rebel, Machinegunner (HEAP)"
 	flags = EQUIPMENT_PRESET_EXTRA
 	assignment = "Machinegunner"
+	paygrades = list(PAY_SHORT_CA3 = JOB_PLAYTIME_TIER_0)
 	skills = /datum/skills/smartgunner
 	access = list(ACCESS_UPP_GENERAL, ACCESS_UPP_MACHINEGUN)
 
@@ -221,7 +268,7 @@
 	//uniform
 	add_canc_uniform(new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e1(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e3(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/general_belt/upp, WEAR_WAIST)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp, WEAR_IN_BELT)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp, WEAR_IN_BELT)
@@ -241,6 +288,7 @@
 /datum/equipment_preset/canc/at
 	name = "CANC Rebel, Anti-Tank"
 	flags = EQUIPMENT_PRESET_EXTRA
+	paygrades = list(PAY_SHORT_CA2 = JOB_PLAYTIME_TIER_0)
 	assignment = "Anti-Tank Rifleman"
 
 /datum/equipment_preset/canc/at/load_gear(mob/living/carbon/human/new_human)
@@ -265,7 +313,7 @@
 	//uniform
 	add_canc_uniform(new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
-	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e1(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e2(new_human), WEAR_ACCESSORY)
 	//jacket
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/faction/UPP/CANC(new_human), WEAR_JACKET)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/general_belt/upp, WEAR_J_STORE)

--- a/code/modules/gear_presets/canc.dm
+++ b/code/modules/gear_presets/canc.dm
@@ -170,6 +170,45 @@
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e1(new_human), WEAR_ACCESSORY)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/general_belt/upp, WEAR_WAIST)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp/standard_fmj, WEAR_IN_BELT)
+	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp/standard_fmj, WEAR_IN_BELT)
+	//jacket
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/suit/marine/smartgunner/upp/canc(new_human), WEAR_JACKET)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/pkp/iff/standard_fmj, WEAR_J_STORE)
+	//limbs
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/shoes/marine/upp/guard/canc(new_human), WEAR_FEET)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/gloves/marine/brown(new_human), WEAR_HANDS)
+	//pockets
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/firstaid/full/alternate(new_human), WEAR_L_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/pistol/alt, WEAR_R_STORE)
+	new_human.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/t73, WEAR_IN_R_STORE)
+	if(prob(30))
+		new_human.equip_to_slot_or_del(new /obj/item/clothing/glasses/mgoggles/orange(new_human), WEAR_IN_HELMET)
+
+/datum/equipment_preset/canc/machinegunner/heap
+	name = "CANC Rebel, Machinegunner (HEAP)"
+	flags = EQUIPMENT_PRESET_EXTRA
+	assignment = "Machinegunner"
+	skills = /datum/skills/smartgunner
+	access = list(ACCESS_UPP_GENERAL, ACCESS_UPP_MACHINEGUN)
+
+/datum/equipment_preset/canc/machinegunner/heap/load_gear(mob/living/carbon/human/new_human)
+	new_human.undershirt = "undershirt"
+	//face
+	new_human.equip_to_slot_or_del(new /obj/item/device/radio/headset/almayer/marine/solardevils/canc(new_human), WEAR_L_EAR)
+	var/random_neckwear_canc = rand(1,4)
+	switch(random_neckwear_canc)
+		if(1,2)
+			add_neckerchief(new_human)
+		if(3)
+			add_facewrap(new_human)
+	//head
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/veteran/canc(new_human), WEAR_HEAD)
+	//uniform
+	add_canc_uniform(new_human)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/storage/smallpouch/upp, WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/clothing/accessory/ranks/canc/e1(new_human), WEAR_ACCESSORY)
+	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/general_belt/upp, WEAR_WAIST)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp, WEAR_IN_BELT)
 	new_human.equip_to_slot_or_del(new /obj/item/ammo_magazine/pkp, WEAR_IN_BELT)
 	//jacket

--- a/code/modules/mob/living/carbon/human/ai/ai_spawner/ai_presets_canc.dm
+++ b/code/modules/mob/living/carbon/human/ai/ai_spawner/ai_presets_canc.dm
@@ -21,6 +21,11 @@
 	desc = "CANC Remnant Force rifleman, QYJ-72-I."
 	path = /datum/equipment_preset/canc/machinegunner
 
+/datum/human_ai_equipment_preset/canc/machinegunner/heap
+	name = "CANC Squad Machinegunner (HEAP)"
+	desc = "CANC Remnant Force rifleman, QYJ-72-I, HEAP"
+	path = /datum/equipment_preset/canc/machinegunner/heap
+
 /datum/human_ai_equipment_preset/canc/at
 	name = "CANC Squad Anti-Tank"
 	desc = "CANC Remnant Force rifleman, Rocket Launcher."

--- a/code/modules/mob/living/carbon/human/ai/ai_spawner/ai_presets_canc.dm
+++ b/code/modules/mob/living/carbon/human/ai/ai_spawner/ai_presets_canc.dm
@@ -41,6 +41,11 @@
 	desc = "CANC Remnant Force squad leader, Random Rifle"
 	path = /datum/equipment_preset/canc/remnant/leader
 
+/datum/human_ai_equipment_preset/canc/officer
+	name = "CANC Officer"
+	desc = "CANC Remnant Force officer, Random Rifle"
+	path = /datum/equipment_preset/canc/remnant/officer
+
 /datum/human_ai_equipment_preset/canc/marksman
 	name = "CANC Squad Marksman"
 	desc = "Type 88 DMR and a dream, make them pay for the Dog War."

--- a/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_clf.dm
+++ b/code/modules/mob/living/carbon/human/ai/squad_spawner/squad_clf.dm
@@ -94,3 +94,31 @@
 		/datum/equipment_preset/canc/remnant/leader = 1,
 		/datum/equipment_preset/canc/remnant = 2,
 	)
+
+/datum/human_ai_squad_preset/clf/canc/recruits
+	name = "CANC Rebel, Recruits"
+	ai_to_spawn = list(
+		/datum/equipment_preset/canc/remnant = 1,
+		/datum/equipment_preset/canc/newblood = 2,
+	)
+
+/datum/human_ai_squad_preset/clf/canc/mgteam
+	name = "CANC Rebel, Machinegun Team"
+	ai_to_spawn = list(
+		/datum/equipment_preset/canc/machinegunner = 1,
+		/datum/equipment_preset/canc/remnant = 1,
+	)
+
+/datum/human_ai_squad_preset/clf/canc/lmgteam
+	name = "CANC Rebel, Light Machinegun Team"
+	ai_to_spawn = list(
+		/datum/equipment_preset/canc/newblood_machinegunner = 1,
+		/datum/equipment_preset/canc/newblood = 1,
+	)
+
+/datum/human_ai_squad_preset/clf/canc/atteam
+	name = "CANC Rebel, Anti-Tank Team"
+	ai_to_spawn = list(
+		/datum/equipment_preset/canc/at = 1,
+		/datum/equipment_preset/canc/remnant = 1,
+	)


### PR DESCRIPTION

# About the pull request

Just been doing some dog war themed stuff lately and noticed:
- CANC squad presets were lacking
- CANC Machinegunner is HEAP by default

so I created a HEAP specific machinegunner and tweaked the default CANC MG to not use HEAP. Also created some new squads - a patrol of 2/3 recruits. An MG buddy team, an LMG buddy team, and an AT buddy team. Nothing crazy.

I also created a clone of the unit leader but made it an 'officer' for HVT purposes. As such I futzed with the ranks and rank lapels - HEAP MG has E3 but regular MG has E2 for example, and bumped Unit Leader from e5 to e4 since e3-4 wasn't being used and I needed officer to be highest paygrade (without adding new paygrades)

Also gave CANC the 'if cold map wear mask' logic.

# Explain why it's good for the game

WOOF

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
add: New CANC MG preset, copied-but-new CANC Officer, new CANC squad spawns
qol: CANC now has cold map checks for masks so hAI doesn't freeze to death
/:cl:

