### PR TITLE
[DNM] [TM ONLY] Shipmap lighting change GM verb

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -103,8 +103,8 @@
 	GLOB.active_areas += src
 	GLOB.all_areas += src
 	reg_in_areas_in_z()
-	if(is_mainship_level(z))
-		GLOB.ship_areas += src
+	GLOB.ship_areas += src
+	if(is_mainship_level(z) && (ceiling > CEILING_GLASS))
 		daytime_affected = FALSE
 	if(ceiling > CEILING_GLASS)
 		daytime_affected = FALSE

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -377,6 +377,7 @@ GLOBAL_LIST_INIT(roundstart_mod_verbs, list(
 		add_verb(src, /client/proc/toggle_rappel_menu)
 		add_verb(src, /client/proc/toggle_fire_support_menu)
 		add_verb(src, /client/proc/gm_lighting)
+		add_verb(src, /client/proc/gm_shipmap_lighting)
 	if(CLIENT_HAS_RIGHTS(src, R_SERVER))
 		add_verb(src, GLOB.admin_verbs_server)
 	if(CLIENT_HAS_RIGHTS(src, R_DEBUG))

--- a/code/modules/admin/game_master/extra_buttons/light_change.dm
+++ b/code/modules/admin/game_master/extra_buttons/light_change.dm
@@ -8,10 +8,11 @@
 	var/light_str = input(usr, "Set the light power.", "Daytime Brightness", "0.3") as null|num
 	var/daytime_color = input(usr, "Please select the color to use.", "Daytime Color") as color|null
 	var/confirm = tgui_alert(usr, "Are you sure you wish to change daytime on the map to this settings?", "Confirm", list("Yes", "No"), 1 HOURS)
+	var/z_level = 2
 	if(confirm != "Yes")
 		return FALSE
 	message_admins("[key_name(usr)] changed lighting on map to [daytime_color] color with [light_str].")
-	lightturfs = block(locate(world.maxx, world.maxy, 2), locate(1, 1, 2))
+	lightturfs = block(locate(world.maxx, world.maxy, z_level), locate(1, 1, 2))
 	for(var/atom/A as anything in lightturfs)
 		if(istype(A.loc,/area/))
 			var/area/targeted = A.loc

--- a/code/modules/admin/game_master/extra_buttons/shipmap_light_change.dm
+++ b/code/modules/admin/game_master/extra_buttons/shipmap_light_change.dm
@@ -1,0 +1,22 @@
+/client/proc/gm_shipmap_lighting()
+	set name = "Change Daytime (Shipmap)"
+	set category = "Game Master.Extras"
+
+	if(!check_rights(R_ADMIN))
+		return
+	var/list/lightturfs
+	var/light_str = input(usr, "Set the light power.", "Shipmap Daytime Brightness", "0.3") as null|num
+	var/daytime_color = input(usr, "Please select the color to use.", "Daytime Color") as color|null
+	var/confirm = tgui_alert(usr, "Are you sure you wish to change daytime on the shipmap to this settings? This should only be used on shipmaps that are ostensibly ground maps.", "Confirm", list("Yes", "No"), 1 HOURS)
+	var/z_level = 3
+	if(confirm != "Yes")
+		return FALSE
+	message_admins("[key_name(usr)] changed lighting on shipmap to [daytime_color] color with [light_str].")
+	lightturfs = block(locate(world.maxx, world.maxy, z_level), locate(1, 1, 3))
+	for(var/atom/A as anything in lightturfs)
+		if(istype(A.loc,/area/))
+			var/area/targeted = A.loc
+			if(!targeted.daytime_affected)
+				lightturfs -= A
+	for(var/turf/T as anything in lightturfs)
+		T.set_light(1, light_str, l_color = daytime_color)

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -1523,6 +1523,7 @@
 #include "code\modules\admin\game_master\extra_buttons\rappel_menu.dm"
 #include "code\modules\admin\game_master\extra_buttons\rename_platoon.dm"
 #include "code\modules\admin\game_master\extra_buttons\screen_alert_menu.dm"
+#include "code\modules\admin\game_master\extra_buttons\shipmap_light_change.dm"
 #include "code\modules\admin\game_master\extra_buttons\toggle_ai_xeno_weeding.dm"
 #include "code\modules\admin\game_master\extra_buttons\toggle_intro.dm"
 #include "code\modules\admin\game_master\extra_buttons\toggle_join_xeno.dm"


### PR DESCRIPTION
# About the pull request

Grabs the shipmap lighting verb from #1221 and makes it a standalone PR to GMs use, don't TM alongside Badayaga for obvious reasons.

# Changelog

:cl:
admin: New shipmap z-level lighting adjustment verb added
/:cl:

