### PR TITLE
[s] Gas Mask Vision Impairment

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -136,6 +136,9 @@
 
 	///Vision impairing effect if worn on head/mask/glasses.
 	var/vision_impair = VISION_IMPAIR_NONE
+	/// only relevant for helmets and masks - if the user would be able to also use a scope too = TRUE
+	var/ignore_zoom_tint = FALSE
+
 
 	///Used for stepping onto flame and seeing how much dmg you take and if you're ignited.
 	var/fire_intensity_resistance
@@ -843,7 +846,13 @@ cases. Override_icon_state should be a list.*/
 	else if(user.stat || !ishuman(user))
 		to_chat(user, SPAN_WARNING("You are unable to focus through \the [zoom_device]."))
 	else if(!zoom && user.client && user.update_tint())
-		to_chat(user, SPAN_WARNING("Your welding equipment gets in the way of you looking through \the [zoom_device]."))
+		var/mob/living/carbon/human/H = user
+		var/tint_allowed = (H.wear_mask && H.wear_mask.ignore_zoom_tint) || (H.head && H.head.ignore_zoom_tint)
+		if(!tint_allowed)
+			to_chat(user, SPAN_WARNING("Your worn equipment gets in the way of you looking through \the [zoom_device]."))
+			return
+		do_zoom(user, tileoffset, viewsize, keep_zoom)
+		return
 	else if(!zoom && user.get_active_hand() != src && !istype(src, /obj/item/clothing/mask))
 		to_chat(user, SPAN_WARNING("You need to hold \the [zoom_device] to look through it."))
 	else if(!zoom)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1200,6 +1200,8 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 /obj/item/clothing/head/helmet/marine/veteran/UPP/heavy
 	name = "\improper 6B79 helmet"
 	desc = "EVA-capable enclosed helmet of the UPP's Naval Infantry. Despite offering a higher armor rating, this helmet's cumbersome design kept it from retaining a larger role in the equipment of the Naval Infantry, and instead is largely reserved for heavy weapons operators and other specialist roles."
+	vision_impair = VISION_IMPAIR_WEAK
+	ignore_zoom_tint = TRUE // they can use scopes
 	icon_state = "upp_helmet_heavy"
 	armor_melee = CLOTHING_ARMOR_MEDIUMHIGH
 	armor_bullet = CLOTHING_ARMOR_MEDIUMHIGH

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1066,6 +1066,8 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	name = "\improper Mk16 tactical helmet"
 	desc = "Standard issue high molecular density polymer combat helmet and ballistic mask of the RMC, though this one has been painted white for service with Weyland Yutani's elite tactical teams. Resistant to glancing hits from small arms and shrapnel, incorporates tactical camera, IFF signal transponder, and heads up display lens. Also features white/black hot IR viewing modes from the camera system."
 	icon_state = "heavy_wy"
+	vision_impair = VISION_IMPAIR_WEAK
+	ignore_zoom_tint = TRUE // they can use scopes
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	flags_inventory = COVEREYES|COVERMOUTH|BLOCKSHARPOBJ|ALLOWINTERNALS|BLOCKGASEFFECT|ALLOWREBREATH|ALLOWCPR
 	flags_inv_hide = HIDEEARS|HIDEEYES|HIDEFACE|HIDEMASK|HIDEALLHAIR
@@ -1082,6 +1084,8 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	icon_state = "commando_helmet"
 	item_state = "commando_helmet"
 	unacidable = 1
+	vision_impair = VISION_IMPAIR_MED
+	ignore_zoom_tint = TRUE // they can use scopes
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	armor_melee = CLOTHING_ARMOR_VERYHIGH
 	armor_bullet = CLOTHING_ARMOR_ULTRAHIGH

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1066,7 +1066,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	name = "\improper Mk16 tactical helmet"
 	desc = "Standard issue high molecular density polymer combat helmet and ballistic mask of the RMC, though this one has been painted white for service with Weyland Yutani's elite tactical teams. Resistant to glancing hits from small arms and shrapnel, incorporates tactical camera, IFF signal transponder, and heads up display lens. Also features white/black hot IR viewing modes from the camera system."
 	icon_state = "heavy_wy"
-	vision_impair = VISION_IMPAIR_WEAK
+	vision_impair = VISION_IMPAIR_MIN
 	ignore_zoom_tint = TRUE // they can use scopes
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	flags_inventory = COVEREYES|COVERMOUTH|BLOCKSHARPOBJ|ALLOWINTERNALS|BLOCKGASEFFECT|ALLOWREBREATH|ALLOWCPR
@@ -1084,7 +1084,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	icon_state = "commando_helmet"
 	item_state = "commando_helmet"
 	unacidable = 1
-	vision_impair = VISION_IMPAIR_MED
+	vision_impair = VISION_IMPAIR_WEAK
 	ignore_zoom_tint = TRUE // they can use scopes
 	flags_armor_protection = BODY_FLAG_HEAD|BODY_FLAG_FACE|BODY_FLAG_EYES
 	armor_melee = CLOTHING_ARMOR_VERYHIGH

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -21,7 +21,7 @@
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
 	siemens_coefficient = 0.9
-	vision_impair = VISION_IMPAIR_HIGH // putting them on for their benefits should have a drawback and feel more immersive
+	vision_impair = VISION_IMPAIR_MED // putting them on for their benefits should have a drawback and feel more immersive
 	var/vision_impair_on_store = VISION_IMPAIR_NONE
 	var/ignore_zoom_tint_on_store = FALSE
 	var/gas_filter_strength = 1 //For gas mask filters
@@ -106,7 +106,7 @@
 	item_state = "helmet"
 	icon_state = "pmc_mask"
 	anti_hug = 3
-	vision_impair = VISION_IMPAIR_WEAK // best in the biz
+	vision_impair = VISION_IMPAIR_MIN // best in the biz
 	ignore_zoom_tint = TRUE // they can use scopes
 	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_NONE
@@ -227,5 +227,5 @@
 	icon_state = "rmc_mask"
 	flags_atom = NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	flags_inventory = COVERMOUTH|COVEREYES|ALLOWINTERNALS|BLOCKGASEFFECT|ALLOWREBREATH|ALLOWCPR
-	vision_impair = VISION_IMPAIR_MED // not as good as PMC but good
+	vision_impair = VISION_IMPAIR_WEAK // not as good as PMC but good
 	ignore_zoom_tint = TRUE // they can use scopes

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -21,7 +21,7 @@
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
 	siemens_coefficient = 0.9
-	vision_impair = VISION_IMPAIR_NONE
+	vision_impair = VISION_IMPAIR_STRONG // putting them on for their benefits should have a drawback and feel more immersive
 	var/gas_filter_strength = 1 //For gas mask filters
 	var/list/filtered_gases = list("phoron", "sleeping_agent", "carbon_dioxide")
 
@@ -86,7 +86,7 @@
 	item_state = "helmet"
 	icon_state = "pmc_mask"
 	anti_hug = 3
-	vision_impair = VISION_IMPAIR_NONE
+	vision_impair = VISION_IMPAIR_MED // best in the biz
 	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_NONE
 	armor_laser = CLOTHING_ARMOR_NONE
@@ -206,3 +206,4 @@
 	icon_state = "rmc_mask"
 	flags_atom = NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	flags_inventory = COVERMOUTH|COVEREYES|ALLOWINTERNALS|BLOCKGASEFFECT|ALLOWREBREATH|ALLOWCPR
+	vision_impair = VISION_IMPAIR_HIGH // not as good as PMC but good

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -21,7 +21,7 @@
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_NONE
 	siemens_coefficient = 0.9
-	vision_impair = VISION_IMPAIR_STRONG // putting them on for their benefits should have a drawback and feel more immersive
+	vision_impair = VISION_IMPAIR_HIGH // putting them on for their benefits should have a drawback and feel more immersive
 	var/gas_filter_strength = 1 //For gas mask filters
 	var/list/filtered_gases = list("phoron", "sleeping_agent", "carbon_dioxide")
 
@@ -86,7 +86,7 @@
 	item_state = "helmet"
 	icon_state = "pmc_mask"
 	anti_hug = 3
-	vision_impair = VISION_IMPAIR_MED // best in the biz
+	vision_impair = VISION_IMPAIR_WEAK // best in the biz
 	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_NONE
 	armor_laser = CLOTHING_ARMOR_NONE
@@ -206,4 +206,4 @@
 	icon_state = "rmc_mask"
 	flags_atom = NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	flags_inventory = COVERMOUTH|COVEREYES|ALLOWINTERNALS|BLOCKGASEFFECT|ALLOWREBREATH|ALLOWCPR
-	vision_impair = VISION_IMPAIR_HIGH // not as good as PMC but good
+	vision_impair = VISION_IMPAIR_MED // not as good as PMC but good

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -22,6 +22,8 @@
 	armor_internaldamage = CLOTHING_ARMOR_NONE
 	siemens_coefficient = 0.9
 	vision_impair = VISION_IMPAIR_HIGH // putting them on for their benefits should have a drawback and feel more immersive
+	var/vision_impair_on_store = VISION_IMPAIR_NONE
+	var/ignore_zoom_tint_on_store = FALSE
 	var/gas_filter_strength = 1 //For gas mask filters
 	var/list/filtered_gases = list("phoron", "sleeping_agent", "carbon_dioxide")
 
@@ -51,6 +53,15 @@
 	helmet_item.flags_inventory |= BLOCKGASEFFECT
 	helmet_item.flags_inv_hide |= HIDEFACE
 
+	vision_impair_on_store = helmet_item.vision_impair
+	ignore_zoom_tint_on_store = helmet_item.ignore_zoom_tint
+	helmet_item.vision_impair = vision_impair
+	helmet_item.ignore_zoom_tint = ignore_zoom_tint
+
+	var/mob/living/carbon/human/H = helmet_item.loc
+	if(H)
+		H.update_tint()
+
 /obj/item/clothing/mask/gas/military/on_exit_storage(obj/item/storage/internal/helmet_internal_inventory)
 	..()
 	if(!istype(helmet_internal_inventory))
@@ -62,6 +73,15 @@
 
 	helmet_item.flags_inventory &= ~(BLOCKGASEFFECT)
 	helmet_item.flags_inv_hide &= ~(HIDEFACE)
+
+	helmet_item.vision_impair = vision_impair_on_store
+	helmet_item.ignore_zoom_tint = ignore_zoom_tint_on_store
+	vision_impair_on_store = VISION_IMPAIR_NONE
+	ignore_zoom_tint_on_store = FALSE
+
+	var/mob/living/carbon/human/H = helmet_item.loc
+	if(H)
+		H.update_tint()
 
 /obj/item/clothing/mask/gas/military/upp
 	name = "\improper ShMB/4 gasmask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -87,6 +87,7 @@
 	icon_state = "pmc_mask"
 	anti_hug = 3
 	vision_impair = VISION_IMPAIR_WEAK // best in the biz
+	ignore_zoom_tint = TRUE // they can use scopes
 	armor_melee = CLOTHING_ARMOR_LOW
 	armor_bullet = CLOTHING_ARMOR_NONE
 	armor_laser = CLOTHING_ARMOR_NONE
@@ -207,3 +208,4 @@
 	flags_atom = NO_NAME_OVERRIDE|NO_SNOW_TYPE
 	flags_inventory = COVERMOUTH|COVEREYES|ALLOWINTERNALS|BLOCKGASEFFECT|ALLOWREBREATH|ALLOWCPR
 	vision_impair = VISION_IMPAIR_MED // not as good as PMC but good
+	ignore_zoom_tint = TRUE // they can use scopes

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -85,7 +85,7 @@
 	light_power = 3
 	light_range = 4
 	light_color = LIGHT_COLOR_TUNGSTEN
-	light_system = DIRECTIONAL_LIGHT
+	light_system = MOVABLE_LIGHT
 
 	var/flashlight_cooldown = 0 //Cooldown for toggling the light
 	var/locate_cooldown = 0 //Cooldown for SL locator
@@ -699,7 +699,7 @@
 
 	light_power = 3
 	light_range = 4
-	light_system = DIRECTIONAL_LIGHT
+	light_system = MOVABLE_LIGHT
 
 	var/flashlight_cooldown = 0 //Cooldown for toggling the light
 	var/locate_cooldown = 0 //Cooldown for SL locator

--- a/code/modules/clothing/suits/marine_armor/_marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor/_marine_armor.dm
@@ -85,7 +85,7 @@
 	light_power = 3
 	light_range = 4
 	light_color = LIGHT_COLOR_TUNGSTEN
-	light_system = MOVABLE_LIGHT
+	light_system = DIRECTIONAL_LIGHT
 
 	var/flashlight_cooldown = 0 //Cooldown for toggling the light
 	var/locate_cooldown = 0 //Cooldown for SL locator
@@ -699,7 +699,7 @@
 
 	light_power = 3
 	light_range = 4
-	light_system = MOVABLE_LIGHT
+	light_system = DIRECTIONAL_LIGHT
 
 	var/flashlight_cooldown = 0 //Cooldown for toggling the light
 	var/locate_cooldown = 0 //Cooldown for SL locator


### PR DESCRIPTION
# About the pull request

Gas masks now (or, once again really) impair your vision - it seems a little silly that they have their positives with zero drawback (I mean, you can even CPR with them on!) so having some vision impairment like they used to in the good ol' days seems like a fun and immersive way to add a cost to when your section leader says "don thy masks" and everyone gets to groan. It also means that players who choose to wear them 24/7 (why???) have to live with this choice. 

# Explain why it's good for the game

Gas masks now have a drawback with their benefit, making it less likely that a player will just choose to wear it all round - risk vs reward baby.

# Testing Photographs and Procedure
tested locally

# Changelog

:cl:
balance: reintroduced vision impairment to gasmasks.
/:cl:

