### PR TITLE
[s] Solo Vics 

### DIFF
--- a/code/__DEFINES/vehicle.dm
+++ b/code/__DEFINES/vehicle.dm
@@ -18,6 +18,7 @@
 #define VEHICLE_SUPPORT_GUNNER_ONE  "1st support gunner"
 #define VEHICLE_SUPPORT_GUNNER_TWO  "2nd support gunner"
 #define VEHICLE_COMMANDER "commander"
+#define VEHICLE_OPERATOR "operator"
 
 #define VEHICLE_SPEED_STATIC 5000 //500 seconds per tile, while not actually static, it's much better than adding check for each movement attempt.
 #define VEHICLE_SPEED_SLOW   30 //3 seconds per tile

--- a/code/__DEFINES/vehicle.dm
+++ b/code/__DEFINES/vehicle.dm
@@ -18,7 +18,6 @@
 #define VEHICLE_SUPPORT_GUNNER_ONE  "1st support gunner"
 #define VEHICLE_SUPPORT_GUNNER_TWO  "2nd support gunner"
 #define VEHICLE_COMMANDER "commander"
-#define VEHICLE_OPERATOR "operator"
 
 #define VEHICLE_SPEED_STATIC 5000 //500 seconds per tile, while not actually static, it's much better than adding check for each movement attempt.
 #define VEHICLE_SPEED_SLOW   30 //3 seconds per tile

--- a/code/datums/vehicles.dm
+++ b/code/datums/vehicles.dm
@@ -50,6 +50,10 @@
 	name = "Command Tank"
 	interior_id = "tank_command"
 
+/datum/map_template/interior/tank_solo
+	name = "Tank (Solo)"
+	interior_id = "tank_solo"
+
 /datum/map_template/interior/upptank
 	name = "UPP Tank"
 	interior_id = "upptank"
@@ -57,6 +61,10 @@
 /datum/map_template/interior/upptank_command
 	name = "UPP Command Tank"
 	interior_id = "upptank_command"
+
+/datum/map_template/interior/upptank_solo
+	name = "UPP Tank (Solo)"
+	interior_id = "upptank_solo"
 
 /datum/map_template/interior/aev
 	name = "AEV"
@@ -113,3 +121,7 @@
 /datum/map_template/interior/uppapc
 	name = "ZSL-68"
 	interior_id = "uppapc"
+
+/datum/map_template/interior/uppapc_solo
+	name = "ZSL-68 (Solo)"
+	interior_id = "uppapc_solo"

--- a/code/modules/vehicles/hardpoints/primary/apc_minigun.dm
+++ b/code/modules/vehicles/hardpoints/primary/apc_minigun.dm
@@ -92,3 +92,6 @@
 	if(old_stage_rate != new_stage_rate)
 		stage_delay_mult = 1 / new_stage_rate
 		SEND_SIGNAL(src, COMSIG_GUN_AUTOFIREDELAY_MODIFIED, fire_delay * stage_delay_mult)
+
+/obj/item/hardpoint/primary/gshk_minigun/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/primary/autocannon.dm
+++ b/code/modules/vehicles/hardpoints/primary/autocannon.dm
@@ -33,3 +33,6 @@
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff),
 		BULLET_TRAIT_ENTRY_ID("vehicles", /datum/element/bullet_trait_damage_boost, 20, GLOB.damage_boost_vehicles),
 	))
+
+/obj/item/hardpoint/primary/autocannon/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/primary/flamer.dm
+++ b/code/modules/vehicles/hardpoints/primary/flamer.dm
@@ -37,3 +37,6 @@
 		return NONE
 
 	return ..()
+
+/obj/item/hardpoint/primary/flamer/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/primary/ltb.dm
+++ b/code/modules/vehicles/hardpoints/primary/ltb.dm
@@ -36,3 +36,6 @@
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff),
 		BULLET_TRAIT_ENTRY_ID("vehicles", /datum/element/bullet_trait_damage_boost, 300, GLOB.damage_boost_vehicles),
 	))
+
+/obj/item/hardpoint/primary/cannon/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/primary/minigun.dm
+++ b/code/modules/vehicles/hardpoints/primary/minigun.dm
@@ -87,3 +87,6 @@
 	if(old_stage_rate != new_stage_rate)
 		stage_delay_mult = 1 / new_stage_rate
 		SEND_SIGNAL(src, COMSIG_GUN_AUTOFIREDELAY_MODIFIED, fire_delay * stage_delay_mult)
+
+/obj/item/hardpoint/primary/minigun/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/primary/p17702.dm
+++ b/code/modules/vehicles/hardpoints/primary/p17702.dm
@@ -36,3 +36,6 @@
 
 	scatter = 0
 	fire_delay = 4 SECONDS
+
+/obj/item/hardpoint/primary/cannon/p17702/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/primary/railgun.dm
+++ b/code/modules/vehicles/hardpoints/primary/railgun.dm
@@ -37,3 +37,6 @@
 
 	scatter = 0
 	fire_delay = 10.0 SECONDS
+
+/obj/item/hardpoint/primary/cannon/railgun/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/secondary/Hj35.dm
+++ b/code/modules/vehicles/hardpoints/secondary/Hj35.dm
@@ -67,3 +67,9 @@
 		"4" = list(39, 0),
 		"8" = list(-5, 10)
 	)
+
+/obj/item/hardpoint/secondary/hj35launcher/solo
+	allowed_seat = VEHICLE_DRIVER
+
+/obj/item/hardpoint/secondary/hj35launcher/upptank/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/secondary/cupola.dm
+++ b/code/modules/vehicles/hardpoints/secondary/cupola.dm
@@ -33,6 +33,9 @@
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff)
 	))
 
+/obj/item/hardpoint/secondary/m56cupola/solo
+	allowed_seat = VEHICLE_DRIVER
+
 /obj/item/hardpoint/secondary/m56cupola/aev
 	name = "\improper Pintle-Mounted M56 RWS"
 	desc = "A remotely-controlled weapon system for armored engineering vehicles using a modified M56."

--- a/code/modules/vehicles/hardpoints/secondary/flamer.dm
+++ b/code/modules/vehicles/hardpoints/secondary/flamer.dm
@@ -60,3 +60,6 @@
 	COOLDOWN_START(src, fire_cooldown, fire_delay)
 
 	return AUTOFIRE_CONTINUE
+
+/obj/item/hardpoint/secondary/small_flamer/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
+++ b/code/modules/vehicles/hardpoints/secondary/grenade_launcher.dm
@@ -43,3 +43,6 @@
 		return NONE
 
 	return ..()
+
+/obj/item/hardpoint/secondary/grenade_launcher/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/secondary/t60p3m.dm
+++ b/code/modules/vehicles/hardpoints/secondary/t60p3m.dm
@@ -38,3 +38,6 @@
 	LAZYADD(traits_to_give, list(
 		BULLET_TRAIT_ENTRY(/datum/element/bullet_trait_iff)
 	))
+
+/obj/item/hardpoint/secondary/t60p3m/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/secondary/tow.dm
+++ b/code/modules/vehicles/hardpoints/secondary/tow.dm
@@ -36,3 +36,5 @@
 		BULLET_TRAIT_ENTRY_ID("vehicles", /datum/element/bullet_trait_damage_boost, 350, GLOB.damage_boost_vehicles),
 	))
 
+/obj/item/hardpoint/secondary/towlauncher/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/hardpoints/support/flare.dm
+++ b/code/modules/vehicles/hardpoints/support/flare.dm
@@ -98,3 +98,6 @@
 	allowed_seat = VEHICLE_GUNNER
 
 	use_muzzle_flash = FALSE
+
+/obj/item/hardpoint/support/flare_launcher/upptank/solo
+	allowed_seat = VEHICLE_DRIVER

--- a/code/modules/vehicles/interior/interactable/seats.dm
+++ b/code/modules/vehicles/interior/interactable/seats.dm
@@ -150,6 +150,31 @@
 
 	return ..()
 
+// Operator's seat
+// This is for solo prop usage ONLY and is not intended for use by actual players
+/obj/structure/bed/chair/comfy/vehicle/solo
+	name = "operator's seat"
+	desc = "Military-grade seat for armored vehicle operator with some controls, switches and indicators. There are banks connected to on-board combat automatics to allow them to assist in a solo-crewed vehicle output."
+	var/image/over_image = null
+	seat = VEHICLE_DRIVER
+	required_skill = SKILL_VEHICLE_CREWMAN
+
+/obj/structure/bed/chair/comfy/vehicle/solo/do_buckle(mob/target, mob/user)
+	required_skill = vehicle.required_skill
+	if(!skillcheck(target, SKILL_VEHICLE, required_skill))
+		if(target == user)
+			to_chat(user, SPAN_WARNING("You have no idea how to operate this thing!"))
+		return FALSE
+
+	for(var/obj/item/I in user.contents)		//prevents shooting while zoomed in, but zoom can still be activated and used without shooting
+		if(I.zoom)
+			I.zoom(user)
+
+	if(vehicle)
+		vehicle.vehicle_faction = target.faction
+
+	return ..()
+
 //custom vehicle seats for armored vehicles
 //spawners located in interior_landmarks
 

--- a/code/modules/vehicles/interior/interior_landmarks.dm
+++ b/code/modules/vehicles/interior/interior_landmarks.dm
@@ -193,6 +193,28 @@
 
 	qdel(src)
 
+/obj/effect/landmark/interior/spawn/vehicle_operator_seat/armor/solo
+	name = "armor operator's seat spawner"
+	icon = 'icons/obj/vehicles/interiors/general.dmi'
+	icon_state = "armor_chair"
+	color = "yellow"
+
+/obj/effect/landmark/interior/spawn/vehicle_operator_seat/armor/solo/on_load(datum/interior/I)
+	var/obj/structure/bed/chair/comfy/vehicle/solo/S = new(loc)
+
+	S.icon = icon
+	S.icon_state = icon_state
+	S.vehicle = I.exterior
+	S.required_skill = S.vehicle.required_skill
+	S.setDir(dir)
+	S.update_icon()
+	S.alpha = alpha
+	S.handle_rotation()
+	S.pixel_x = pixel_x
+	S.pixel_y = pixel_y
+
+	qdel(src)
+
 /obj/effect/landmark/interior/spawn/vehicle_support_gunner_seat
 	name = "1st support gunner's seat spawner"
 	icon = 'icons/obj/vehicles/interiors/general.dmi'

--- a/code/modules/vehicles/multitile/multitile_verbs.dm
+++ b/code/modules/vehicles/multitile/multitile_verbs.dm
@@ -241,6 +241,19 @@
 		return
 	T.toggle_gyro(usr)
 
+/obj/vehicle/multitile/proc/toggle_apc_gyrostabilizer() //probs a cleaner way to do this but I can't be arsed
+	set name = "Toggle APC Turret Gyrostabilizer"
+	set desc = "Toggles APC Turret Gyrostabilizer allowing it independent movement regardless of hull direction."
+	set category = "Vehicle"
+
+	var/mob/M = usr
+	if(!M || !istype(M))
+		return
+
+	var/obj/vehicle/multitile/V = M.interactee
+	if(!istype(V))
+		return
+
 	var/obj/item/hardpoint/holder/apc_turret/A = null
 	for(var/obj/item/hardpoint/holder/apc_turret/AT in V.hardpoints)
 		A = AT

--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -226,6 +226,52 @@
 	icon_state = "tank_base_n"
 
 /*
+** SOLO TANKS
+*/
+/obj/vehicle/multitile/tank/solo
+	interior_map = /datum/map_template/interior/tank_solo
+
+/obj/vehicle/multitile/tank/solo/add_seated_verbs(mob/living/user, seat)
+	if(!user.client)
+		return
+	add_verb(user.client, list(
+		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/get_status_info,
+		/obj/vehicle/multitile/proc/open_controls_guide,
+		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/toggle_door_lock,
+		/obj/vehicle/multitile/proc/activate_horn,
+		/obj/vehicle/multitile/proc/cycle_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+	))
+	user.client.change_view(view_boost, seat)
+	user.client.pixel_x = 0
+	user.client.pixel_y = 0
+
+/obj/vehicle/multitile/tank/solo/remove_seated_verbs(mob/living/user, seat)
+	if(!user.client)
+		return
+	remove_verb(user.client, list(
+		/obj/vehicle/multitile/proc/get_status_info,
+		/obj/vehicle/multitile/proc/open_controls_guide,
+		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_door_lock,
+		/obj/vehicle/multitile/proc/activate_horn,
+		/obj/vehicle/multitile/proc/cycle_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+	))
+	user.client.change_view(GLOB.world_view_size, seat)
+	user.client.pixel_x = 0
+	user.client.pixel_y = 0
+	SStgui.close_user_uis(user, src)
+
+//Called when players try to move vehicle
+//Another wrapper for try_move()
+/obj/vehicle/multitile/tank/solo/relaymove(mob/user, direction)
+	return ..()
+
+/*
 ** COMMAND TANK
 */
 /obj/vehicle/multitile/tank/command
@@ -629,4 +675,58 @@
 	for(var/obj/item/hardpoint/holder/tank_turret/tonkturret in vic.hardpoints)
 		tonkturret.add_hardpoint(new /obj/item/hardpoint/primary/cannon)
 		tonkturret.add_hardpoint(new /obj/item/hardpoint/secondary/m56cupola)
+		break
+
+//SOLO TANK PRESET: fully armed and ready to rumble
+/obj/effect/vehicle_spawner/tank/solo/spawn_vehicle()
+	var/obj/vehicle/multitile/tank/solo/TANK = new (loc)
+
+	load_misc(TANK)
+	load_hardpoints(TANK)
+	handle_direction(TANK)
+	TANK.update_icon()
+
+	return TANK
+
+/obj/effect/vehicle_spawner/tank/solo/load_hardpoints(obj/vehicle/multitile/tank/vic)
+	vic.add_hardpoint(new /obj/item/hardpoint/support/weapons_sensor)
+	vic.add_hardpoint(new /obj/item/hardpoint/armor/paladin)
+	vic.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	vic.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret)
+	for(var/obj/item/hardpoint/holder/tank_turret/tonkturret in vic.hardpoints)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/primary/cannon/solo)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/secondary/m56cupola/solo)
+		break
+
+//PRESET: minigun kit
+/obj/effect/vehicle_spawner/tank/solo/minigun/load_hardpoints(obj/vehicle/multitile/tank/vic)
+	vic.add_hardpoint(new /obj/item/hardpoint/support/weapons_sensor)
+	vic.add_hardpoint(new /obj/item/hardpoint/armor/ballistic)
+	vic.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	vic.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret)
+	for(var/obj/item/hardpoint/holder/tank_turret/tonkturret in vic.hardpoints)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/primary/minigun/solo)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/secondary/small_flamer/solo)
+		break
+
+//PRESET: dragon flamer kit
+/obj/effect/vehicle_spawner/tank/solo/flamer/load_hardpoints(obj/vehicle/multitile/tank/vic)
+	vic.add_hardpoint(new /obj/item/hardpoint/support/overdrive_enhancer)
+	vic.add_hardpoint(new /obj/item/hardpoint/armor/ballistic)
+	vic.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	vic.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret)
+	for(var/obj/item/hardpoint/holder/tank_turret/tonkturret in vic.hardpoints)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/primary/flamer/solo)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/secondary/grenade_launcher/solo)
+		break
+
+//PRESET: autocannon kit
+/obj/effect/vehicle_spawner/tank/solo/autocannon/load_hardpoints(obj/vehicle/multitile/tank/vic)
+	vic.add_hardpoint(new /obj/item/hardpoint/support/weapons_sensor)
+	vic.add_hardpoint(new /obj/item/hardpoint/armor/ballistic)
+	vic.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	vic.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret)
+	for(var/obj/item/hardpoint/holder/tank_turret/tonkturret in vic.hardpoints)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/primary/autocannon/solo)
+		tonkturret.add_hardpoint(new /obj/item/hardpoint/secondary/towlauncher/solo)
 		break

--- a/code/modules/vehicles/uppapc/uppapc.dm
+++ b/code/modules/vehicles/uppapc/uppapc.dm
@@ -177,6 +177,43 @@
 			to_chat(user, SPAN_XENO("The path over [src] is obstructed!"))
 			return
 
+/obj/vehicle/multitile/apc/uppapc/solo
+	interior_map = /datum/map_template/interior/uppapc_solo
+
+/obj/vehicle/multitile/apc/uppapc/solo/add_seated_verbs(mob/living/M, seat)
+	if(!M.client)
+		return
+	add_verb(M.client, list(
+		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/get_status_info,
+		/obj/vehicle/multitile/proc/open_controls_guide,
+		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/toggle_door_lock,
+		/obj/vehicle/multitile/proc/activate_horn,
+		/obj/vehicle/multitile/proc/cycle_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+	))
+
+/obj/vehicle/multitile/apc/uppapc/solo/remove_seated_verbs(mob/living/M, seat)
+	if(!M.client)
+		return
+	remove_verb(M.client, list(
+		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/get_status_info,
+		/obj/vehicle/multitile/proc/open_controls_guide,
+		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/toggle_door_lock,
+		/obj/vehicle/multitile/proc/activate_horn,
+		/obj/vehicle/multitile/proc/cycle_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+	))
+	SStgui.close_user_uis(M, src)
+
+//Called when players try to move vehicle
+//Another wrapper for try_move()
+/obj/vehicle/multitile/apc/uppapc/solo/relaymove(mob/user, direction)
+	return ..()
+
 /*
 ** PRESETS SPAWNERS
 */
@@ -240,4 +277,32 @@
 	for(var/obj/item/hardpoint/holder/apc_turret/AT in V.hardpoints)
 		AT.add_hardpoint(new /obj/item/hardpoint/primary/gshk_minigun)
 		AT.add_hardpoint(new /obj/item/hardpoint/secondary/hj35launcher)
+		break
+
+//SOLO APC PRESET: fully armed and ready to rumble
+/obj/effect/vehicle_spawner/apc/uppapc/solo/spawn_vehicle()
+	var/obj/vehicle/multitile/apc/uppapc/solo/APC = new (loc)
+
+	load_misc(APC)
+	load_hardpoints(APC)
+	handle_direction(APC)
+	APC.update_icon()
+
+//PRESET: default hardpoints, installed minigun
+/obj/effect/vehicle_spawner/apc/uppapc/solo/load_hardpoints(obj/vehicle/multitile/apc/uppapc/V)
+	V.add_hardpoint(new /obj/item/hardpoint/locomotion/apc_wheels/zsl_wheels)
+	V.add_hardpoint(new /obj/item/hardpoint/holder/apc_turret)
+	V.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upp)
+	for(var/obj/item/hardpoint/holder/apc_turret/AT in V.hardpoints)
+		AT.add_hardpoint(new /obj/item/hardpoint/primary/gshk_minigun/solo)
+		break
+
+//PRESET: default hardpoints, installed minigun, hj-35
+/obj/effect/vehicle_spawner/apc/uppapc/solo/minigunhj35/load_hardpoints(obj/vehicle/multitile/apc/uppapc/V)
+	V.add_hardpoint(new /obj/item/hardpoint/locomotion/apc_wheels/zsl_wheels)
+	V.add_hardpoint(new /obj/item/hardpoint/holder/apc_turret)
+	V.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upp)
+	for(var/obj/item/hardpoint/holder/apc_turret/AT in V.hardpoints)
+		AT.add_hardpoint(new /obj/item/hardpoint/primary/gshk_minigun/solo)
+		AT.add_hardpoint(new /obj/item/hardpoint/secondary/hj35launcher/solo)
 		break

--- a/code/modules/vehicles/uppapc/uppapc.dm
+++ b/code/modules/vehicles/uppapc/uppapc.dm
@@ -111,6 +111,7 @@
 	else if(seat == VEHICLE_GUNNER)
 		add_verb(M.client, list(
 			/obj/vehicle/multitile/proc/cycle_hardpoint,
+			/obj/vehicle/multitile/proc/toggle_apc_gyrostabilizer,
 		))
 
 /obj/vehicle/multitile/apc/uppapc/remove_seated_verbs(mob/living/M, seat)
@@ -131,6 +132,7 @@
 	else if(seat == VEHICLE_GUNNER)
 		remove_verb(M.client, list(
 			/obj/vehicle/multitile/proc/cycle_hardpoint,
+			/obj/vehicle/multitile/proc/toggle_apc_gyrostabilizer,
 		))
 
 //Called when players try to move vehicle
@@ -191,7 +193,7 @@
 		/obj/vehicle/multitile/proc/toggle_door_lock,
 		/obj/vehicle/multitile/proc/activate_horn,
 		/obj/vehicle/multitile/proc/cycle_hardpoint,
-		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+		/obj/vehicle/multitile/proc/toggle_apc_gyrostabilizer,
 	))
 
 /obj/vehicle/multitile/apc/uppapc/solo/remove_seated_verbs(mob/living/M, seat)
@@ -205,7 +207,7 @@
 		/obj/vehicle/multitile/proc/toggle_door_lock,
 		/obj/vehicle/multitile/proc/activate_horn,
 		/obj/vehicle/multitile/proc/cycle_hardpoint,
-		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+		/obj/vehicle/multitile/proc/toggle_apc_gyrostabilizer,
 	))
 	SStgui.close_user_uis(M, src)
 

--- a/code/modules/vehicles/upptank/upptank.dm
+++ b/code/modules/vehicles/upptank/upptank.dm
@@ -47,6 +47,49 @@
 	add_hardpoint(new /obj/item/hardpoint/holder/tank_turret/uppturret)
 
 
+/obj/vehicle/multitile/tank/upptank/solo
+	interior_map = /datum/map_template/interior/upptank_solo
+
+/obj/vehicle/multitile/tank/upptank/solo/add_seated_verbs(mob/living/user, seat)
+	if(!user.client)
+		return
+	add_verb(user.client, list(
+		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/get_status_info,
+		/obj/vehicle/multitile/proc/open_controls_guide,
+		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/toggle_door_lock,
+		/obj/vehicle/multitile/proc/activate_horn,
+		/obj/vehicle/multitile/proc/cycle_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+	))
+	user.client.change_view(view_boost, seat)
+	user.client.pixel_x = 0
+	user.client.pixel_y = 0
+
+/obj/vehicle/multitile/tank/upptank/solo/remove_seated_verbs(mob/living/user, seat)
+	if(!user.client)
+		return
+	remove_verb(user.client, list(
+		/obj/vehicle/multitile/proc/get_status_info,
+		/obj/vehicle/multitile/proc/open_controls_guide,
+		/obj/vehicle/multitile/proc/name_vehicle,
+		/obj/vehicle/multitile/proc/switch_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_door_lock,
+		/obj/vehicle/multitile/proc/activate_horn,
+		/obj/vehicle/multitile/proc/cycle_hardpoint,
+		/obj/vehicle/multitile/proc/toggle_gyrostabilizer,
+	))
+	user.client.change_view(GLOB.world_view_size, seat)
+	user.client.pixel_x = 0
+	user.client.pixel_y = 0
+	SStgui.close_user_uis(user, src)
+
+//Called when players try to move vehicle
+//Another wrapper for try_move()
+/obj/vehicle/multitile/tank/upptank/solo/relaymove(mob/user, direction)
+	return ..()
+
 /obj/vehicle/multitile/tank/upptank/command
 	name = "Cheetah 2B Light Command Tank"
 	desc = "A giant piece of state-approved armor with a big gun and enhanced comms equipment, you know what to do. Entrance in the back."
@@ -320,4 +363,63 @@
 		TT.add_hardpoint(new /obj/item/hardpoint/primary/cannon/p17702)
 		TT.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upptank)
 		TT.add_hardpoint(new /obj/item/hardpoint/secondary/t60p3m)
+		break
+
+//SOLO TANK PRESET: fully armed and ready to rumble
+/obj/effect/vehicle_spawner/upptank/solo/spawn_vehicle()
+	var/obj/vehicle/multitile/tank/upptank/solo/TANK = new (loc)
+
+	load_misc(TANK)
+	load_hardpoints(TANK)
+	handle_direction(TANK)
+	TANK.update_icon()
+
+	return TANK
+
+//PRESET: default hardpoints, MG secondaries
+/obj/effect/vehicle_spawner/upptank/solo/load_hardpoints(obj/vehicle/multitile/tank/V)
+	V.add_hardpoint(new /obj/item/hardpoint/support/weapons_sensor)
+	V.add_hardpoint(new /obj/item/hardpoint/armor/reactive)
+	V.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	V.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret/uppturret)
+	for(var/obj/item/hardpoint/holder/tank_turret/uppturret/TT in V.hardpoints)
+		TT.add_hardpoint(new /obj/item/hardpoint/primary/cannon/p17702/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upptank/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/secondary/t60p3m/solo)
+		break
+
+//PRESET: TOW hardpoints, TOW launcher secondaries
+/obj/effect/vehicle_spawner/upptank/solo/tow/load_hardpoints(obj/vehicle/multitile/tank/V)
+	V.add_hardpoint(new /obj/item/hardpoint/support/weapons_sensor)
+	V.add_hardpoint(new /obj/item/hardpoint/armor/reactive)
+	V.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	V.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret/uppturret)
+	for(var/obj/item/hardpoint/holder/tank_turret/uppturret/TT in V.hardpoints)
+		TT.add_hardpoint(new /obj/item/hardpoint/primary/cannon/p17702/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upptank/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/secondary/hj35launcher/upptank/solo)
+		break
+
+//PRESET: Anti-Armored hardpoints, MG secondaries, Railgun
+/obj/effect/vehicle_spawner/upptank/solo/railgun/load_hardpoints(obj/vehicle/multitile/tank/V)
+	V.add_hardpoint(new /obj/item/hardpoint/support/weapons_sensor)
+	V.add_hardpoint(new /obj/item/hardpoint/armor/reactive)
+	V.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	V.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret/uppturret)
+	for(var/obj/item/hardpoint/holder/tank_turret/uppturret/TT in V.hardpoints)
+		TT.add_hardpoint(new /obj/item/hardpoint/primary/cannon/railgun/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upptank/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/secondary/t60p3m/solo)
+		break
+
+//PRESET: Anti-Armored Sniper hardpoints, MG secondaries, Railgun
+/obj/effect/vehicle_spawner/upptank/solo/sniper_railgun/load_hardpoints(obj/vehicle/multitile/tank/V)
+	V.add_hardpoint(new /obj/item/hardpoint/support/artillery_module)
+	V.add_hardpoint(new /obj/item/hardpoint/armor/reactive)
+	V.add_hardpoint(new /obj/item/hardpoint/locomotion/treads)
+	V.add_hardpoint(new /obj/item/hardpoint/holder/tank_turret/uppturret)
+	for(var/obj/item/hardpoint/holder/tank_turret/uppturret/TT in V.hardpoints)
+		TT.add_hardpoint(new /obj/item/hardpoint/primary/cannon/railgun/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/support/flare_launcher/upptank/solo)
+		TT.add_hardpoint(new /obj/item/hardpoint/secondary/t60p3m/solo)
 		break

--- a/maps/interiors/tank_solo.dmm
+++ b/maps/interiors/tank_solo.dmm
@@ -1,0 +1,207 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"d" = (
+/turf/open/shuttle/vehicle/floor_3_13,
+/area/interior/vehicle/tank)
+"g" = (
+/obj/structure/interior_wall/tank{
+	alpha = 50;
+	icon_state = "exterior_1";
+	layer = 5.2;
+	pixel_y = 32
+	},
+/turf/open/void/vehicle,
+/area/space)
+"i" = (
+/turf/open/void/vehicle,
+/area/space)
+"j" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "back_3"
+	},
+/turf/open/void/vehicle,
+/area/space)
+"l" = (
+/obj/structure/interior_wall/tank{
+	alpha = 50;
+	icon_state = "exterior_2";
+	layer = 5.2;
+	pixel_y = 32
+	},
+/turf/open/void/vehicle,
+/area/space)
+"q" = (
+/obj/structure/vehicle_locker/tank{
+	pixel_y = 11
+	},
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med/lifeboat{
+	name = "Vehicle NanoMed";
+	pixel_x = -5;
+	pixel_y = 31
+	},
+/obj/structure/extinguisher_cabinet/lifeboat{
+	pixel_x = 9;
+	pixel_y = 31
+	},
+/turf/open/shuttle/vehicle/floor_1_11,
+/area/interior/vehicle/tank)
+"r" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "front_3"
+	},
+/turf/open/void/vehicle,
+/area/space)
+"t" = (
+/obj/structure/prop/tank,
+/turf/open/shuttle/vehicle/floor_3_1_1,
+/area/interior/vehicle/tank)
+"v" = (
+/obj/structure/interior_wall/tank{
+	layer = 2
+	},
+/turf/open/void/vehicle,
+/area/space)
+"w" = (
+/obj/structure/prop/tank{
+	icon_state = "prop5"
+	},
+/obj/structure/prop/tank{
+	icon_state = "prop7";
+	pixel_y = 32
+	},
+/turf/open/shuttle/vehicle/floor_3_8,
+/area/interior/vehicle/tank)
+"y" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "back_2"
+	},
+/turf/open/void/vehicle,
+/area/space)
+"z" = (
+/obj/structure/prop/tank{
+	icon_state = "prop3"
+	},
+/turf/open/shuttle/vehicle/floor_3_4,
+/area/interior/vehicle/tank)
+"A" = (
+/obj/effect/landmark/interior/spawn/entrance{
+	dir = 8;
+	exit_type = /obj/structure/interior_exit/vehicle/tank;
+	name = "back entrance marker";
+	tag = "back"
+	},
+/obj/structure/phone_base{
+	dir = 8;
+	layer = 3.1;
+	name = "Tank Telephone";
+	phone_category = "Vehicles";
+	phone_id = "M34A2 Longstreet Light Tank";
+	pixel_x = 22;
+	pixel_y = -14
+	},
+/turf/open/shuttle/vehicle/floor_1_12,
+/area/interior/vehicle/tank)
+"B" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "front_2"
+	},
+/turf/open/void/vehicle,
+/area/space)
+"C" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "front_1"
+	},
+/turf/open/void/vehicle,
+/area/space)
+"D" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "back_1"
+	},
+/turf/open/void/vehicle,
+/area/space)
+"H" = (
+/obj/structure/interior_wall/tank{
+	icon_state = "exterior_3";
+	layer = 5.2;
+	pixel_y = 32
+	},
+/turf/open/void/vehicle,
+/area/space)
+"M" = (
+/obj/structure/prop/tank{
+	icon_state = "prop1"
+	},
+/turf/open/shuttle/vehicle/floor_3_9,
+/area/interior/vehicle/tank)
+"Q" = (
+/obj/structure/prop/tank{
+	density = 0;
+	icon_state = "prop6";
+	pixel_y = 32
+	},
+/obj/structure/prop/tank{
+	density = 0;
+	icon_state = "prop8_extra";
+	layer = 4.12
+	},
+/obj/structure/prop/tank{
+	density = 0;
+	icon_state = "prop4"
+	},
+/obj/effect/landmark/interior/spawn/vehicle_operator_seat/armor/solo{
+	dir = 4
+	},
+/turf/open/shuttle/vehicle/floor_3_7,
+/area/interior/vehicle/tank)
+"W" = (
+/obj/structure/prop/tank{
+	icon_state = "prop2"
+	},
+/obj/effect/landmark/interior/spawn/weapons_loader{
+	layer = 2;
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/effect/landmark/interior/spawn/interior_camera{
+	dir = 10;
+	layer = 3.2;
+	pixel_x = 12;
+	pixel_y = 58
+	},
+/turf/open/shuttle/vehicle/floor_3_3,
+/area/interior/vehicle/tank)
+
+(1,1,1) = {"
+j
+y
+y
+D
+i
+"}
+(2,1,1) = {"
+v
+q
+A
+d
+g
+"}
+(3,1,1) = {"
+v
+Q
+W
+t
+l
+"}
+(4,1,1) = {"
+v
+w
+z
+M
+H
+"}
+(5,1,1) = {"
+r
+B
+B
+C
+i
+"}

--- a/maps/interiors/uppapc_solo.dmm
+++ b/maps/interiors/uppapc_solo.dmm
@@ -1,0 +1,308 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/vehicle_locker/movie{
+	pixel_y = 31;
+	layer = 2.9;
+	pixel_x = 1
+	},
+/obj/structure/bed/chair/vehicle{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/turf/open/shuttle/vehicle/floor_3_7,
+/area/interior/vehicle/uppapc)
+"c" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = -8
+	},
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 1;
+	pixel_x = 8;
+	pixel_y = -11
+	},
+/turf/open/shuttle/vehicle/floor_3_5,
+/area/interior/vehicle/uppapc)
+"d" = (
+/turf/open/shuttle/vehicle/floor_1_1_3,
+/area/interior/vehicle/uppapc)
+"h" = (
+/obj/structure/surface/table/reinforced/toc/east{
+	pixel_y = -5
+	},
+/obj/structure/machinery/prop/almayer/CICmap{
+	density = 0;
+	icon_state = "toc_map";
+	layer = 2.97;
+	name = "Tactical Map Display";
+	pixel_y = 13;
+	pixel_x = -7
+	},
+/obj/structure/phone_base/toc{
+	pixel_x = 11;
+	pixel_y = 13;
+	phone_category = "Vehicles";
+	name = "APC reciever";
+	phone_id = "ZSL-68 'Pilgrim'"
+	},
+/turf/open/shuttle/vehicle/floor_1_8,
+/area/interior/vehicle/uppapc)
+"i" = (
+/obj/effect/landmark/interior/spawn/weapons_loader{
+	icon = 'icons/obj/vehicles/interiors/uppapc.dmi'
+	},
+/turf/open/shuttle/vehicle/floor_3_10_1,
+/area/interior/vehicle/uppapc)
+"k" = (
+/turf/open/void/vehicle/unopacity,
+/area/space)
+"l" = (
+/obj/structure/surface/table/reinforced/toc/west{
+	pixel_y = -5
+	},
+/obj/structure/machinery/computer/overwatch/upp/toc{
+	pixel_y = 14
+	},
+/obj/structure/machinery/computer/shuttle/dropship/flight/toc/upp{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/turf/open/shuttle/vehicle/floor_1_7,
+/area/interior/vehicle/uppapc)
+"r" = (
+/obj/structure/vehicle_locker/movie{
+	pixel_y = 31;
+	layer = 2.9
+	},
+/obj/effect/landmark/interior/spawn/entrance{
+	dir = 8;
+	exit_type = /obj/structure/interior_exit/vehicle/uppapc/rear;
+	pixel_x = -32;
+	icon = 'icons/obj/vehicles/interiors/uppapc.dmi';
+	tag = "rear center"
+	},
+/obj/structure/bed/chair/vehicle{
+	pixel_x = -8;
+	pixel_y = 14
+	},
+/obj/structure/bed/chair/vehicle{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/turf/open/shuttle/vehicle/floor_3_11,
+/area/interior/vehicle/uppapc)
+"v" = (
+/obj/structure/bed/chair/vehicle/toc{
+	dir = 1;
+	pixel_y = 19;
+	pixel_x = 16
+	},
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 4;
+	pixel_x = -6;
+	pixel_y = 25
+	},
+/turf/open/shuttle/vehicle/floor_1_10,
+/area/interior/vehicle/uppapc)
+"x" = (
+/turf/open/shuttle/vehicle/floor_3_9,
+/area/interior/vehicle/uppapc)
+"y" = (
+/obj/effect/landmark/interior/spawn/vehicle_operator_seat/armor/solo{
+	dir = 4
+	},
+/turf/open/shuttle/vehicle/floor_3_8,
+/area/interior/vehicle/uppapc)
+"z" = (
+/turf/open/void/vehicle,
+/area/space)
+"E" = (
+/obj/structure/extinguisher_cabinet/lifeboat{
+	icon = 'icons/obj/vehicles/interiors/general.dmi';
+	pixel_x = 10;
+	pixel_y = 30
+	},
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med/vehicle{
+	pixel_y = 30;
+	pixel_x = -6
+	},
+/obj/effect/landmark/interior/spawn/interior_camera{
+	dir = 5;
+	pixel_x = -18;
+	pixel_y = 38
+	},
+/turf/open/shuttle/vehicle/floor_1_5,
+/area/interior/vehicle/uppapc)
+"F" = (
+/turf/open/shuttle/vehicle/floor_1_12,
+/area/interior/vehicle/uppapc)
+"I" = (
+/obj/structure/vehicle_locker{
+	pixel_x = -1;
+	pixel_y = -2;
+	icon = 'icons/obj/vehicles/interiors/uppapc.dmi';
+	layer = 3.01
+	},
+/turf/open/void/vehicle/unopacity,
+/area/space)
+"J" = (
+/obj/structure/prop/vehicle/uppapc{
+	pixel_x = 16;
+	pixel_y = -32
+	},
+/turf/open/void/vehicle,
+/area/space)
+"K" = (
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/effect/landmark/interior/spawn/entrance{
+	alpha = 50;
+	exit_type = /obj/structure/interior_exit/vehicle/uppapc;
+	name = "Right APC door";
+	tag = "right"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	pixel_y = 20;
+	anchored = 1
+	},
+/turf/open/shuttle/vehicle/floor_3,
+/area/interior/vehicle/uppapc)
+"L" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = -8
+	},
+/turf/open/shuttle/vehicle/floor_3_5,
+/area/interior/vehicle/uppapc)
+"M" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = -8
+	},
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 1;
+	pixel_x = 8;
+	pixel_y = -11
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	pixel_y = 20;
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/shuttle/vehicle/floor_3_10_1,
+/area/interior/vehicle/uppapc)
+"O" = (
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/structure/bed/chair/vehicle{
+	dir = 1;
+	pixel_x = -8
+	},
+/turf/open/shuttle/vehicle/floor_3_8,
+/area/interior/vehicle/uppapc)
+"R" = (
+/turf/open/shuttle/vehicle/floor_1_8,
+/area/interior/vehicle/uppapc)
+"S" = (
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/effect/landmark/interior/spawn/entrance{
+	alpha = 50;
+	dir = 1;
+	exit_type = /obj/structure/interior_exit/vehicle/uppapc;
+	name = "Left APC door";
+	pixel_y = 32;
+	tag = "left"
+	},
+/obj/effect/decal/warning_stripes{
+	icon_state = "door_warning";
+	anchored = 1
+	},
+/turf/open/shuttle/vehicle/floor_3,
+/area/interior/vehicle/uppapc)
+
+(1,1,1) = {"
+z
+z
+z
+z
+J
+"}
+(2,1,1) = {"
+z
+k
+r
+M
+k
+"}
+(3,1,1) = {"
+z
+l
+v
+L
+k
+"}
+(4,1,1) = {"
+z
+h
+d
+c
+k
+"}
+(5,1,1) = {"
+z
+k
+E
+O
+k
+"}
+(6,1,1) = {"
+z
+S
+R
+F
+K
+"}
+(7,1,1) = {"
+z
+k
+a
+i
+k
+"}
+(8,1,1) = {"
+z
+I
+y
+x
+k
+"}
+(9,1,1) = {"
+z
+z
+z
+z
+z
+"}

--- a/maps/interiors/upptank_solo.dmm
+++ b/maps/interiors/upptank_solo.dmm
@@ -1,0 +1,138 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/prop/tank{
+	icon = 'icons/obj/vehicles/interiors/upptank.dmi'
+	},
+/turf/open/shuttle/vehicle/floor_2,
+/area/interior/vehicle/upptank)
+"b" = (
+/turf/open/void/vehicle,
+/area/space)
+"f" = (
+/obj/effect/landmark/interior/spawn/interior_camera{
+	dir = 10;
+	layer = 3.2;
+	pixel_x = -14;
+	pixel_y = 33
+	},
+/obj/effect/landmark/interior/spawn/interior_viewport{
+	dir = 1;
+	pixel_y = -11
+	},
+/obj/structure/bed/chair/dropship{
+	name = "handrail seat";
+	icon = 'icons/obj/structures/handrail.dmi';
+	icon_state = "handrail_strata";
+	indestructible = 1
+	},
+/turf/open/shuttle/vehicle/floor_1_14,
+/area/interior/vehicle/upptank)
+"v" = (
+/obj/structure/prop/vehicle/upptank{
+	pixel_x = 16
+	},
+/turf/open/void/vehicle,
+/area/space)
+"H" = (
+/obj/structure/machinery/cm_vending/sorted/medical/wall_med/vehicle{
+	pixel_y = 27;
+	pixel_x = -7
+	},
+/obj/structure/vehicle_locker/tank/upp2{
+	pixel_x = 3;
+	pixel_y = 27
+	},
+/obj/structure/vehicle_locker/tank/upp2{
+	pixel_x = 11;
+	pixel_y = 27
+	},
+/obj/effect/landmark/interior/spawn/entrance{
+	dir = 8;
+	exit_type = /obj/structure/interior_exit/vehicle/tank;
+	name = "back entrance marker";
+	tag = "back"
+	},
+/turf/open/shuttle/vehicle/floor_1_13,
+/area/interior/vehicle/upptank)
+"M" = (
+/turf/open/void/vehicle/unopacity,
+/area/interior/vehicle/upptank)
+"Q" = (
+/obj/effect/landmark/interior/spawn/weapons_loader{
+	icon = 'icons/obj/vehicles/interiors/upptank.dmi';
+	pixel_x = -6;
+	pixel_y = 23
+	},
+/obj/structure/vehicle_locker/tank/upp1{
+	pixel_x = -25;
+	pixel_y = 16
+	},
+/turf/open/shuttle/vehicle/floor_3_13,
+/area/interior/vehicle/upptank)
+"R" = (
+/obj/structure/extinguisher_cabinet/lifeboat{
+	icon = 'icons/obj/vehicles/interiors/general.dmi';
+	pixel_x = -3;
+	pixel_y = 18;
+	layer = 3.1
+	},
+/obj/structure/phone_base{
+	icon = 'icons/obj/vehicles/interiors/movie.dmi';
+	pixel_x = 18;
+	pixel_y = 31;
+	layer = 3.1;
+	name = "Tank Telephone";
+	phone_id = "Cheetah 2A Light Tank";
+	phone_category = "Vehicles"
+	},
+/obj/effect/landmark/interior/spawn/vehicle_operator_seat/armor/solo{
+	dir = 4
+	},
+/turf/open/shuttle/vehicle/floor_3_12,
+/area/interior/vehicle/upptank)
+"S" = (
+/turf/open/void/vehicle,
+/area/interior/vehicle/upptank)
+
+(1,1,1) = {"
+b
+b
+b
+b
+v
+"}
+(2,1,1) = {"
+b
+b
+M
+H
+b
+"}
+(3,1,1) = {"
+b
+S
+Q
+f
+b
+"}
+(4,1,1) = {"
+b
+S
+a
+R
+b
+"}
+(5,1,1) = {"
+b
+b
+b
+b
+b
+"}
+(6,1,1) = {"
+b
+b
+b
+b
+b
+"}


### PR DESCRIPTION
# About the pull request

GMs might want to pilot a special vic themselves for a setup, or only have a handful of ghosts available to get a convoy rolling - now this makes it easier! 

These vehicle_spawner solo variants only have the one seat that controls both driving and gunning. 

NOTE: there is no way to turn the turret, but with Gyro Stabiliser you can enable/disable it to keep your turret aimed in one direction as part of the setup.


/

# Explain why it's good for the game

Easier to get vics fielded in ops

# Testing Photographs and Procedure
tested locally

# Changelog

:cl:
add: solo vic variants for USCM Tank, UPP Tank, and UPP APC
mapadd: solo vic variants
fix: apc turret gyro code was nested and inaccessible within the tank gyro code so i made an explicit apc gyro proc
/:cl:
